### PR TITLE
Implement new `dist` module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ help: Makefile
 test:
 	pytest --cov=microhapulator --doctest-modules microhapulator/*.py microhapulator/*/test_*.py
 
+## test4:     execute the automated test suite in multithreaded mode
+test4:
+	pytest -n 4 --cov=microhapulator --doctest-modules microhapulator/*.py microhapulator/*/test_*.py
+
 ## devdeps:   install development dependencies
 devdeps:
 	pip install --upgrade pip setuptools

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -18,6 +18,7 @@ from microhapulator import population
 
 # Subcommands and command-line interface
 from microhapulator import contrib
+from microhapulator import dist
 from microhapulator import refr
 from microhapulator import sim
 from microhapulator import type

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -12,12 +12,14 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import microhapulator
 from sys import stderr
 from . import contrib
+from . import dist
 from . import refr
 from . import sim
 from . import type
 
 mains = {
     'contrib': microhapulator.contrib.main,
+    'dist': microhapulator.dist.main,
     'refr': microhapulator.refr.main,
     'sim': microhapulator.sim.main,
     'type': microhapulator.type.main,
@@ -25,6 +27,7 @@ mains = {
 
 subparser_funcs = {
     'contrib': contrib.subparser,
+    'dist': dist.subparser,
     'refr': refr.subparser,
     'sim': sim.subparser,
     'type': type.subparser,

--- a/microhapulator/cli/dist.py
+++ b/microhapulator/cli/dist.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+def subparser(subparsers):
+    cli = subparsers.add_parser('dist')
+    cli.add_argument(
+        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
+        'default, output is written to the terminal (standard output)'
+    )
+    cli.add_argument(
+        'gt1', help='genotype data (in JSON format) for individual 1'
+    )
+    cli.add_argument(
+        'gt2', help='genotype data (in JSON format) for individual 2'
+    )

--- a/microhapulator/dist.py
+++ b/microhapulator/dist.py
@@ -11,9 +11,7 @@ import json
 import microhapulator
 
 
-def dist(gtfile1, gtfile2):
-    gt1 = microhapulator.type.Genotype(filename=gtfile1)
-    gt2 = microhapulator.type.Genotype(filename=gtfile2)
+def dist(gt1, gt2):
     allloci = set(gt1.alleles()).union(gt2.alleles())
     hammdist = 0
     for locus in allloci:
@@ -28,7 +26,9 @@ def dist(gtfile1, gtfile2):
 
 
 def main(args):
-    d = dist(args.gt1, args.gt2)
+    gt1 = microhapulator.type.Genotype(filename=args.gt1)
+    gt2 = microhapulator.type.Genotype(filename=args.gt2)
+    d = dist(gt1, gt2)
     data = {
         'hamming_distance': d,
     }

--- a/microhapulator/dist.py
+++ b/microhapulator/dist.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+
+
+def dist(gtfile1, gtfile2):
+    gt1 = microhapulator.type.Genotype(filename=gtfile1)
+    gt2 = microhapulator.type.Genotype(filename=gtfile2)
+    allloci = set(gt1.alleles()).union(gt2.alleles())
+    hammdist = 0
+    for locus in allloci:
+        allele1, allele2 = None, None
+        if locus in gt1.data:
+            allele1 = gt1.data[locus]['genotype']
+        if locus in gt2.data:
+            allele2 = gt2.data[locus]['genotype']
+        if allele1 != allele2:
+            hammdist += 1
+    return hammdist
+
+
+def main(args):
+    d = dist(args.gt1, args.gt2)
+    data = {
+        'hamming_distance': d,
+    }
+    with microhapulator.open(args.out, 'w') as fh:
+        json.dump(data, fh, indent=4)

--- a/microhapulator/tests/data/gujarati-ind1-gt.json
+++ b/microhapulator/tests/data/gujarati-ind1-gt.json
@@ -1,0 +1,76 @@
+{
+    "MHDBL000190": {
+        "allele_counts": {
+            "C,A": 3,
+            "C,G": 3436,
+            "C,T": 3,
+            "T,G": 1
+        },
+        "genotype": [
+            "C,G"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3216.3,
+        "min_coverage": 2,
+        "num_discarded_reads": 282
+    },
+    "MHDBL000191": {
+        "allele_counts": {
+            "C,C,G": 1,
+            "G,A,G": 1,
+            "G,C,G": 3337,
+            "G,C,T": 1,
+            "G,G,G": 2,
+            "G,T,G": 1,
+            "T,C,G": 1
+        },
+        "genotype": [
+            "G,C,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3224.5,
+        "min_coverage": 68,
+        "num_discarded_reads": 399
+    },
+    "MHDBL000196": {
+        "allele_counts": {
+            "A,A": 1577,
+            "A,C": 1,
+            "A,G": 1,
+            "A,T": 1,
+            "G,A": 3,
+            "G,C": 2,
+            "G,G": 1557,
+            "G,T": 2
+        },
+        "genotype": [
+            "A,A",
+            "G,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3215.0,
+        "min_coverage": 1,
+        "num_discarded_reads": 596
+    },
+    "MHDBL000199": {
+        "allele_counts": {
+            "A,C,A": 2,
+            "A,C,C": 1669,
+            "A,T,C": 1,
+            "G,C,A": 2,
+            "G,C,C": 1651,
+            "G,C,G": 1,
+            "G,C,T": 2,
+            "G,T,C": 2,
+            "T,C,C": 1
+        },
+        "genotype": [
+            "A,C,C",
+            "G,C,C"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3215.5,
+        "min_coverage": 3,
+        "num_discarded_reads": 406
+    }
+}

--- a/microhapulator/tests/data/gujarati-ind2-gt.json
+++ b/microhapulator/tests/data/gujarati-ind2-gt.json
@@ -1,0 +1,67 @@
+{
+    "MHDBL000190": {
+        "allele_counts": {
+            "A,A": 2,
+            "A,G": 1694,
+            "C,A": 2,
+            "C,G": 1681,
+            "T,G": 2
+        },
+        "genotype": [
+            "A,G",
+            "C,G"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3215.3,
+        "min_coverage": 1,
+        "num_discarded_reads": 345
+    },
+    "MHDBL000191": {
+        "allele_counts": {
+            "A,C,G": 1,
+            "G,A,G": 3,
+            "G,C,A": 1,
+            "G,C,G": 3338,
+            "G,C,T": 1,
+            "G,G,G": 1,
+            "G,T,G": 1,
+            "T,C,G": 1
+        },
+        "genotype": [
+            "G,C,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3224.4,
+        "min_coverage": 53,
+        "num_discarded_reads": 395
+    },
+    "MHDBL000196": {
+        "allele_counts": {
+            "G,A": 3,
+            "G,C": 5,
+            "G,G": 3120,
+            "T,G": 2
+        },
+        "genotype": [
+            "G,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3214.9,
+        "min_coverage": 4,
+        "num_discarded_reads": 609
+    },
+    "MHDBL000199": {
+        "allele_counts": {
+            "A,C,C": 1663,
+            "G,C,C": 1687
+        },
+        "genotype": [
+            "A,C,C",
+            "G,C,C"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3224.1,
+        "min_coverage": 64,
+        "num_discarded_reads": 391
+    }
+}

--- a/microhapulator/tests/data/gujarati-ind3-gt.json
+++ b/microhapulator/tests/data/gujarati-ind3-gt.json
@@ -1,0 +1,72 @@
+{
+    "MHDBL000190": {
+        "allele_counts": {
+            "C,A": 4,
+            "C,G": 3391,
+            "C,T": 1,
+            "T,G": 1
+        },
+        "genotype": [
+            "C,G"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3224.4,
+        "min_coverage": 61,
+        "num_discarded_reads": 324
+    },
+    "MHDBL000191": {
+        "allele_counts": {
+            "A,C,G": 1,
+            "G,A,G": 1,
+            "G,C,A": 1,
+            "G,C,C": 1,
+            "G,C,G": 3333,
+            "G,C,T": 1,
+            "G,T,G": 1
+        },
+        "genotype": [
+            "G,C,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3224.4,
+        "min_coverage": 68,
+        "num_discarded_reads": 412
+    },
+    "MHDBL000196": {
+        "allele_counts": {
+            "A,A": 1581,
+            "A,C": 1,
+            "A,G": 5,
+            "A,T": 2,
+            "G,A": 2,
+            "G,G": 1560,
+            "G,T": 1
+        },
+        "genotype": [
+            "A,A",
+            "G,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3214.2,
+        "min_coverage": 1,
+        "num_discarded_reads": 593
+    },
+    "MHDBL000199": {
+        "allele_counts": {
+            "A,A,C": 3,
+            "A,C,A": 3,
+            "A,C,C": 3302,
+            "A,C,G": 1,
+            "A,C,T": 3,
+            "A,T,C": 1,
+            "C,C,C": 1
+        },
+        "genotype": [
+            "A,C,C"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3215.5,
+        "min_coverage": 1,
+        "num_discarded_reads": 426
+    }
+}

--- a/microhapulator/tests/data/gujarati-ind4-gt.json
+++ b/microhapulator/tests/data/gujarati-ind4-gt.json
@@ -1,0 +1,67 @@
+{
+    "MHDBL000190": {
+        "allele_counts": {
+            "C,G": 3412,
+            "C,T": 1,
+            "T,G": 1
+        },
+        "genotype": [
+            "C,G"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3215.3,
+        "min_coverage": 1,
+        "num_discarded_reads": 305
+    },
+    "MHDBL000191": {
+        "allele_counts": {
+            "A,C,G": 1,
+            "C,C,A": 1,
+            "G,C,A": 1674,
+            "G,C,C": 1,
+            "G,C,G": 1672,
+            "G,G,A": 1,
+            "G,T,A": 2,
+            "G,T,G": 2
+        },
+        "genotype": [
+            "G,C,A",
+            "G,C,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3215.2,
+        "min_coverage": 1,
+        "num_discarded_reads": 398
+    },
+    "MHDBL000196": {
+        "allele_counts": {
+            "A,G": 1,
+            "G,A": 6,
+            "G,C": 5,
+            "G,G": 3111,
+            "G,T": 6
+        },
+        "genotype": [
+            "G,G"
+        ],
+        "max_coverage": 3754,
+        "mean_coverage": 3224.3,
+        "min_coverage": 61,
+        "num_discarded_reads": 615
+    },
+    "MHDBL000199": {
+        "allele_counts": {
+            "A,C,A": 2,
+            "A,C,C": 3338,
+            "C,C,C": 2,
+            "G,C,C": 1
+        },
+        "genotype": [
+            "A,C,C"
+        ],
+        "max_coverage": 3744,
+        "mean_coverage": 3215.8,
+        "min_coverage": 3,
+        "num_discarded_reads": 398
+    }
+}

--- a/microhapulator/tests/test_dist.py
+++ b/microhapulator/tests/test_dist.py
@@ -24,7 +24,9 @@ from tempfile import NamedTemporaryFile
     ('gujarati-ind3-gt.json', 'gujarati-ind4-gt.json', 2),
 ])
 def test_dist_gujarati(gt1, gt2, dist):
-    assert microhapulator.dist.dist(data_file(gt1), data_file(gt2)) == dist
+    g1 = microhapulator.type.Genotype(data_file(gt1))
+    g2 = microhapulator.type.Genotype(data_file(gt2))
+    assert microhapulator.dist.dist(g1, g2) == dist
 
 
 def test_dist_cli():

--- a/microhapulator/tests/test_dist.py
+++ b/microhapulator/tests/test_dist.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+from microhapulator.tests import data_file
+import pytest
+from tempfile import NamedTemporaryFile
+
+
+@pytest.mark.parametrize('gt1,gt2,dist', [
+    ('gujarati-ind1-gt.json', 'gujarati-ind1-gt.json', 0),
+    ('gujarati-ind1-gt.json', 'gujarati-ind2-gt.json', 2),
+    ('gujarati-ind1-gt.json', 'gujarati-ind3-gt.json', 1),
+    ('gujarati-ind1-gt.json', 'gujarati-ind4-gt.json', 3),
+    ('gujarati-ind2-gt.json', 'gujarati-ind3-gt.json', 3),
+    ('gujarati-ind2-gt.json', 'gujarati-ind4-gt.json', 3),
+    ('gujarati-ind3-gt.json', 'gujarati-ind4-gt.json', 2),
+])
+def test_dist_gujarati(gt1, gt2, dist):
+    assert microhapulator.dist.dist(data_file(gt1), data_file(gt2)) == dist
+
+
+def test_dist_cli():
+    with NamedTemporaryFile() as outfile:
+        arglist = [
+            'dist', '--out', outfile.name, data_file('gujarati-ind2-gt.json'),
+            data_file('gujarati-ind3-gt.json')
+        ]
+        args = microhapulator.cli.parse_args(arglist)
+        microhapulator.dist.main(args)
+        with open(outfile.name, 'r') as fh:
+            assert json.load(fh) == {"hamming_distance": 3}

--- a/microhapulator/type.py
+++ b/microhapulator/type.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 import json
 import microhapulator
 import pysam
-import sys
 
 
 class Genotype(object):
@@ -49,6 +48,12 @@ class Genotype(object):
             return json.dumps(self.data, indent=4, sort_keys=True)
         else:
             return json.dump(self.data, file, indent=4, sort_keys=True)
+
+    def alleles(self):
+        a = dict()
+        for locusid in sorted(self.data):
+            a[locusid] = ':'.join(self.data[locusid]['genotype'])
+        return a
 
 
 def parse_variant_offsets_from_fasta_headers(fasta):


### PR DESCRIPTION
This update includes a new `dist` module for computing the Hamming distance between two genotypes (aggregated over all loci). The initial implementation of the distance calculation is naive and unsophisticated: if the genotype call for an individual isn't exactly the same as the genotype call for a different individual at that locus, the distance is incremented by 1. We should consider improvements that take into account: 1) some alleles are more similar than other alleles; and 2) how to handle comparison of a homozygous allele vs a heterzygous allele (i.e. what is the distance between the homozygous genotype call `A,T,T,C` and the heterozygous call `A,T,T,C` and `G,T,T,C`).

Despite the naive implementation, preliminary testing suggests that it this approach is sufficient to distinguish matching genotypes from non-matches.

Partially fulfills #5.