### PR TITLE
New `getrefr` module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
     - pip install git+https://github.com/bioforensics/MicroHapDB.git
     - pip install .
     - mhpl8r getrefr
+#     For some reason, on TravisCI there's some confusion between the installed package data path and the working package data path
     - bash -c 'ln -s $(mhpl8r getrefr --path)* microhapulator/data/'
 script:
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
     - pip install git+https://github.com/bioforensics/happer.git
     - pip install git+https://github.com/bioforensics/MicroHapDB.git
     - pip install .
+    - mhpl8r getrefr
 script:
     - make refr
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - pip install git+https://github.com/bioforensics/MicroHapDB.git
     - pip install .
 script:
-    - mhpl8r getrefr
+    - mhpl8r getrefr --debug
     - make test
     - make style
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
     - pip install git+https://github.com/bioforensics/happer.git
     - pip install git+https://github.com/bioforensics/MicroHapDB.git
     - pip install .
-    - mhpl8r getrefr --debug
+    - mhpl8r getrefr
+    - bash -c 'ln -s $(mhpl8r getrefr --path)* microhapulator/data/'
 script:
     - make test
     - make style

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ install:
     - pip install git+https://github.com/bioforensics/happer.git
     - pip install git+https://github.com/bioforensics/MicroHapDB.git
     - pip install .
-    - mhpl8r getrefr
 script:
-    - make refr
+    - mhpl8r getrefr
     - make test
     - make style
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
     - pip install git+https://github.com/bioforensics/happer.git
     - pip install git+https://github.com/bioforensics/MicroHapDB.git
     - pip install .
-script:
     - mhpl8r getrefr --debug
+script:
     - make test
     - make style
 after_success:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include microhapulator/_version.py
+recursive-include microhapulator/data *
 recursive-include microhapulator/tests/data *

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,3 @@ clean:
 ## style:     check code style against PEP8
 style:
 	pycodestyle --max-line-length=99 microhapulator/*.py microhapulator/*/*.py
-
-## refr:      download GRCh38 reference genome to current directory and index
-refr:
-	wget -O hg38.fasta.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz
-	gunzip hg38.fasta.gz
-	faidx hg38.fasta chr1:100-150 > /dev/null

--- a/README.md
+++ b/README.md
@@ -21,7 +21,18 @@ Installation with bioconda is recommended.
 conda install -c bioconda microhapulator
 ```
 
-If you'd prefer to install with pip, see [.travis.yml](.travis.yml) and [setup.py](setup.py) for hints.
+> ***NOTE**: If you'd prefer to install with pip, see [.travis.yml](.travis.yml) and [setup.py](setup.py) for hints.*
+
+You must also "install" the GRCh38 human reference genome into a dedicated "package data" directory.
+
+```
+mhpl8r getrefr
+```
+
+By default, this grabs the reference genome directly from UCSC.
+If you have downloaded the reference genome previously, you can provide the file path to the `mhpl8r getrefr` command.
+
+
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Invoke `mhpl8r <subcmd> --help` and replace `<subcmd>` with one of the
 subcommands listed below to see instructions for that operation.
 
 Subcommands:
-  subcmd             contrib, dist, mixture, refr, sim, type
+  subcmd             contrib, dist, getrefr, mixture, refr, sim, type
 
 Global arguments:
   -h, --help         show this help message and exit

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -11,6 +11,8 @@
 import builtins
 from contextlib import contextmanager
 from gzip import open as gzopen
+import os
+from pkg_resources import resource_filename
 import sys
 
 # Internal modules
@@ -20,6 +22,7 @@ from microhapulator import panel
 # Subcommands and command-line interface
 from microhapulator import contrib
 from microhapulator import dist
+from microhapulator import getrefr
 from microhapulator import mixture
 from microhapulator import refr
 from microhapulator import sim
@@ -35,6 +38,12 @@ del get_versions
 
 logstream = None
 teelog = False
+
+
+def package_file(path):
+    pathparts = path.split('/')
+    relpath = os.path.join('data', *pathparts)
+    return resource_filename('microhapulator', relpath)
 
 
 @contextmanager

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -13,6 +13,7 @@ import microhapulator
 from sys import stderr
 from . import contrib
 from . import dist
+from . import getrefr
 from . import mixture
 from . import refr
 from . import sim
@@ -21,6 +22,7 @@ from . import type
 mains = {
     'contrib': microhapulator.contrib.main,
     'dist': microhapulator.dist.main,
+    'getrefr': microhapulator.getrefr.main,
     'mixture': microhapulator.mixture.main,
     'refr': microhapulator.refr.main,
     'sim': microhapulator.sim.main,
@@ -30,6 +32,7 @@ mains = {
 subparser_funcs = {
     'contrib': contrib.subparser,
     'dist': dist.subparser,
+    'getrefr': getrefr.subparser,
     'mixture': mixture.subparser,
     'refr': refr.subparser,
     'sim': sim.subparser,

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+def subparser(subparsers):
+    cli = subparsers.add_parser('getrefr')
+    cli.add_argument('filepath', nargs='?', help='path to a local copy of the '
+                     'GRCh38 reference genome; if not provided, it is '
+                     'downloaded from UCSC (requires an internet connection)')

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -10,6 +10,7 @@
 
 def subparser(subparsers):
     cli = subparsers.add_parser('getrefr')
+    cli.add_argument('--debug', action='store_true', help='debugging output')
     cli.add_argument('filepath', nargs='?', help='path to a local copy of the '
                      'GRCh38 reference genome; if not provided, it is '
                      'downloaded from UCSC (requires an internet connection)')

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -11,6 +11,8 @@
 def subparser(subparsers):
     cli = subparsers.add_parser('getrefr')
     cli.add_argument('--debug', action='store_true', help='debugging output')
+    cli.add_argument('--path', action='store_true', help='print reference '
+                     'file path and exit')
     cli.add_argument('filepath', nargs='?', help='path to a local copy of the '
                      'GRCh38 reference genome; if not provided, it is '
                      'downloaded from UCSC (requires an internet connection)')

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -10,7 +10,6 @@
 
 def subparser(subparsers):
     cli = subparsers.add_parser('getrefr')
-    cli.add_argument('--debug', action='store_true', help='debugging output')
     cli.add_argument('--path', action='store_true', help='print reference '
                      'file path and exit')
     cli.add_argument('filepath', nargs='?', help='path to a local copy of the '

--- a/microhapulator/cli/mixture.py
+++ b/microhapulator/cli/mixture.py
@@ -52,4 +52,3 @@ def subparser(subparsers):
         'FASTQ format to FILE; by default, reads are written to terminal '
         '(standard output)'
     )
-    cli.add_argument('refr', help='reference genome file')

--- a/microhapulator/cli/refr.py
+++ b/microhapulator/cli/refr.py
@@ -25,9 +25,6 @@ def subparser(subparsers):
         'in length'
     )
     cli.add_argument(
-        'refrfasta', help='reference genome file'
-    )
-    cli.add_argument(
         'panel', nargs='*', help='list of MicroHapDB locus IDs; by default, a '
         'panel of 22 ALFRED microhaplotype loci is used'
     )

--- a/microhapulator/cli/sim.py
+++ b/microhapulator/cli/sim.py
@@ -58,6 +58,5 @@ def subparser(subparsers):
         'sequences in FASTA format to FILE'
     )
 
-    cli.add_argument('refr', help='reference genome file')
     cli.add_argument('popid', nargs='+', help='population ID(s)')
     cli._action_groups[1], cli._action_groups[-1] = cli._action_groups[-1], cli._action_groups[1]

--- a/microhapulator/data/.gitignore
+++ b/microhapulator/data/.gitignore
@@ -1,1 +1,2 @@
-hg38.fasta hg38.fasta.fai
+hg38.fasta
+hg38.fasta.fai

--- a/microhapulator/data/.gitignore
+++ b/microhapulator/data/.gitignore
@@ -1,0 +1,1 @@
+hg38.fasta hg38.fasta.fai

--- a/microhapulator/getrefr.py
+++ b/microhapulator/getrefr.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+from hashlib import sha1
+import microhapulator
+import pyfaidx
+from shutil import copyfileobj
+from subprocess import check_call
+from urllib.request import urlopen
+
+
+def download_refr():
+    url = 'http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz'
+    outfilegz = microhapulator.package_file('hg38.fasta.gz')
+    outfile = microhapulator.package_file('hg38.fasta')
+    microhapulator.plog('[MicroHapulator::getrefr] Downloading GRCh38 reference')
+    with urlopen(url) as instream:
+        with open(outfilegz, 'wb') as outstream:
+            copyfileobj(instream, outstream)
+    microhapulator.plog('[MicroHapulator::getrefr] Decompressing reference')
+    check_call(['gunzip', '-f', outfilegz])
+
+
+def install_refr(infile):
+    outfile = microhapulator.package_file('hg38.fasta')
+    microhapulator.plog('[MicroHapulator::getrefr] Copying GRCh38 reference')
+    with microhapulator.open(infile, 'r') as instream:
+        with microhapulator.open(outfile, 'w') as outstream:
+            copyfileobj(instream, outstream)
+
+
+def compute_refr_hash():
+    refrfile = microhapulator.package_file('hg38.fasta')
+    sha = sha1()
+    with microhapulator.open(refrfile, 'r') as fh:
+        while True:
+            block = fh.read(2**10)
+            if not block:
+                break
+            sha.update(block.encode('utf-8'))
+    return sha.hexdigest()
+
+
+def getrefr(infile=None):
+    if infile is None:
+        download_refr()
+    else:
+        install_refr(infile)
+    hashes = [
+        '09b3f6ab110124cb230d028c3689f803f2a95fba',
+        'c44a85ab746fe98ce1945022c643a4c289d2f3ce',
+    ]
+    if compute_refr_hash() not in hashes:
+        raise ValueError('checksum failure')
+    microhapulator.plog('[MicroHapulator::getrefr] Indexing reference')
+    refr = pyfaidx.Fasta(microhapulator.package_file('hg38.fasta'))
+
+
+def main(args):
+    getrefr(args.filepath)

--- a/microhapulator/getrefr.py
+++ b/microhapulator/getrefr.py
@@ -47,7 +47,7 @@ def compute_refr_hash():
     return sha.hexdigest()
 
 
-def getrefr(infile=None, debug=False):
+def getrefr(infile=None):
     if infile is None:
         download_refr()
     else:
@@ -60,15 +60,10 @@ def getrefr(infile=None, debug=False):
         raise ValueError('checksum failure')
     microhapulator.plog('[MicroHapulator::getrefr] Indexing reference')
     refr = pyfaidx.Fasta(microhapulator.package_file('hg38.fasta'))
-    if debug:
-        microhapulator.plog(
-            '[MicroHapulator::getrefr] Reference genome now in place at',
-            microhapulator.package_file('hg38.fasta')
-        )
 
 
 def main(args):
     if args.path:
         print(microhapulator.package_file('hg38.fasta'))
         return
-    getrefr(args.filepath, debug=args.debug)
+    getrefr(args.filepath)

--- a/microhapulator/getrefr.py
+++ b/microhapulator/getrefr.py
@@ -68,4 +68,7 @@ def getrefr(infile=None, debug=False):
 
 
 def main(args):
+    if args.path:
+        print(microhapulator.package_file('hg38.fasta'))
+        return
     getrefr(args.filepath, debug=args.debug)

--- a/microhapulator/getrefr.py
+++ b/microhapulator/getrefr.py
@@ -47,7 +47,7 @@ def compute_refr_hash():
     return sha.hexdigest()
 
 
-def getrefr(infile=None):
+def getrefr(infile=None, debug=False):
     if infile is None:
         download_refr()
     else:
@@ -60,7 +60,12 @@ def getrefr(infile=None):
         raise ValueError('checksum failure')
     microhapulator.plog('[MicroHapulator::getrefr] Indexing reference')
     refr = pyfaidx.Fasta(microhapulator.package_file('hg38.fasta'))
+    if debug:
+        microhapulator.plog(
+            '[MicroHapulator::getrefr] Reference genome now in place at',
+            microhapulator.package_file('hg38.fasta')
+        )
 
 
 def main(args):
-    getrefr(args.filepath)
+    getrefr(args.filepath, debug=args.debug)

--- a/microhapulator/mixture.py
+++ b/microhapulator/mixture.py
@@ -23,7 +23,7 @@ def calc_n_reads_from_proportions(n, totalreads, prop):
     return [int(totalreads * x) for x in normprop]
 
 
-def mixture(individuals, panel, refr, relaxed=False, hapseeds=None, seqseeds=None,
+def mixture(individuals, panel, relaxed=False, hapseeds=None, seqseeds=None,
             seqthreads=1, totalreads=1000000, proportions=None):
     n = len(individuals)
     if hapseeds is None:
@@ -42,7 +42,7 @@ def mixture(individuals, panel, refr, relaxed=False, hapseeds=None, seqseeds=Non
         message = 'Individual population={pop} numreads={n}'.format(pop=','.join(indiv), n=nreads)
         microhapulator.plog('[MicroHapulator::mixture]', message)
         simulator = microhapulator.sim.sim(
-            indiv, panel, refr, relaxed=relaxed, hapseed=hapseed, seqseed=seqseed,
+            indiv, panel, relaxed=relaxed, hapseed=hapseed, seqseed=seqseed,
             seqthreads=seqthreads, numreads=nreads, readsignature=readsignature,
             readindex=reads_sequenced,
         )
@@ -55,7 +55,7 @@ def main(args=None):
     if args is None:  # pragma: no cover
         args = get_parser().parse_args()
     simulator = mixture(
-        args.indiv, args.panel, args.refr, relaxed=args.relaxed, hapseeds=args.hap_seeds,
+        args.indiv, args.panel, relaxed=args.relaxed, hapseeds=args.hap_seeds,
         seqseeds=args.seq_seeds, seqthreads=args.seq_threads, totalreads=args.num_reads,
         proportions=args.proportions,
     )

--- a/microhapulator/refr.py
+++ b/microhapulator/refr.py
@@ -26,7 +26,7 @@ def main(args=None):
     if args is None:  # pragma: no cover
         args = get_parser().parse_args()
     locusids = panel_loci(args.panel)
-    seqindex = Fastaidx(args.refrfasta)
+    seqindex = Fastaidx(microhapulator.package_file('hg38.fasta'))
     with microhapulator.open(args.out, 'w') as fh:
         seqiter = get_seqs(locusids, seqindex, delta=args.delta, minlength=args.min_length)
         for defline, sequence in seqiter:

--- a/microhapulator/sim.py
+++ b/microhapulator/sim.py
@@ -60,12 +60,12 @@ def simulate_genotype(popids, panel, hapseed=None, relaxed=False, outfile=None):
     return genotype
 
 
-def sim(popids, panel, refrfile, relaxed=False, hapseed=None, gtfile=None, hapfile=None,
+def sim(popids, panel, relaxed=False, hapseed=None, gtfile=None, hapfile=None,
         seqseed=None, seqthreads=2, numreads=500000, readsignature=None, readindex=0, debug=False):
     genotype = simulate_genotype(
         popids, panel, hapseed=hapseed, relaxed=relaxed, outfile=gtfile
     )
-    seqindex = Fastaidx(refrfile)
+    seqindex = Fastaidx(microhapulator.package_file('hg38.fasta'))
     mutator = mutate(genotype.seqstream(seqindex), genotype.bedstream)
     with optional_outfile(hapfile) as fh:
         for defline, sequence in mutator:
@@ -112,7 +112,7 @@ def main(args=None):
     if args is None:  # pragma: no cover
         args = get_parser().parse_args()
     simulator = sim(
-        args.popid, args.panel, args.refr, relaxed=args.relaxed, hapseed=args.hap_seed,
+        args.popid, args.panel, relaxed=args.relaxed, hapseed=args.hap_seed,
         gtfile=args.genotype, hapfile=args.haploseq, seqseed=args.seq_seed,
         seqthreads=args.seq_threads, numreads=args.num_reads,
     )

--- a/microhapulator/tests/test_mixture.py
+++ b/microhapulator/tests/test_mixture.py
@@ -40,7 +40,7 @@ def test_even_mixture(capsys):
     indiv_pops = [(numpy.random.choice(popids), numpy.random.choice(popids)) for _ in range(n)]
     panel = microhapulator.panel.panel_allpops()[:5]
     simulator = microhapulator.mixture.mixture(
-        indiv_pops, panel, 'hg38.fasta', totalreads=500, seqthreads=2,
+        indiv_pops, panel, totalreads=500, seqthreads=2,
     )
     for m, read in enumerate(simulator):
         pass
@@ -52,7 +52,7 @@ def test_uneven_mixture(capfd):
     simulator = microhapulator.mixture.mixture(
         [['MHDBP000021'], ['MHDBP000009'], ['MHDBP000081']],
         ['MHDBL000002', 'MHDBL000003', 'MHDBL000007', 'MHDBL000013', 'MHDBL000017'],
-        'hg38.fasta', seqthreads=2, totalreads=500, proportions=[0.5, 0.3, 0.2]
+        seqthreads=2, totalreads=500, proportions=[0.5, 0.3, 0.2]
     )
     for read in simulator:
         pass
@@ -68,21 +68,21 @@ def test_mixture_failure_modes():
 
     with pytest.raises(ValueError) as ve:
         simulator = microhapulator.mixture.mixture(
-            indivs, panel, 'hg38.fasta', totalreads=500, hapseeds=[42, 1776]
+            indivs, panel, totalreads=500, hapseeds=[42, 1776]
         )
         list(simulator)
     assert 'individuals must match number of "--hap-seeds" and "--seq-seeds"' in str(ve)
 
     with pytest.raises(ValueError) as ve:
         simulator = microhapulator.mixture.mixture(
-            indivs, panel, 'hg38.fasta', totalreads=500, proportions=[0.5, 0.3, 0.1, 0.1]
+            indivs, panel, totalreads=500, proportions=[0.5, 0.3, 0.1, 0.1]
         )
         list(simulator)
     assert 'mismatch between contributor number and proportions' in str(ve)
 
     with pytest.raises(ValueError) as ve:
         simulator = microhapulator.mixture.mixture(
-            indivs, panel, 'hg38.fasta', totalreads=500, proportions=[1, 100, 10000]
+            indivs, panel, totalreads=500, proportions=[1, 100, 10000]
         )
         list(simulator)
     assert 'specified proportions result in 0 reads for 1 or more individuals' in str(ve)
@@ -93,7 +93,7 @@ def test_mixture_main(capsys):
         'mixture', '--indiv', 'MHDBP000052', '--indiv', 'MHDBP000052',
         '--panel', 'MHDBL000002', 'MHDBL000003', 'MHDBL000007', 'MHDBL000013', 'MHDBL000017',
         '--proportions', '0.8', '0.2', '--num-reads', '500', '--seq-threads', '2',
-        '--hap-seeds', '3579', '2468', '--seq-seeds', '42', '1776', '--', 'hg38.fasta'
+        '--hap-seeds', '3579', '2468', '--seq-seeds', '42', '1776',
     ]
     args = microhapulator.cli.parse_args(arglist)
     microhapulator.mixture.main(args)

--- a/microhapulator/tests/test_refr.py
+++ b/microhapulator/tests/test_refr.py
@@ -16,7 +16,7 @@ from tempfile import NamedTemporaryFile
 
 
 def test_refr_simple():
-    seqindex = pyfaidx.Fasta('hg38.fasta')
+    seqindex = pyfaidx.Fasta(microhapulator.package_file('hg38.fasta'))
     seqiter = microhapulator.refr.get_seqs(['MHDBL000185'], seqindex)
     seqs = list(seqiter)
     assert len(seqs) == 1
@@ -28,7 +28,7 @@ def test_refr_simple():
 def test_refr_cli_simple():
     with NamedTemporaryFile() as outfile:
         arglist = [
-            'refr', '--min-length', '250', '--out', outfile.name, 'hg38.fasta',
+            'refr', '--min-length', '250', '--out', outfile.name,
             'mh06KK-008', 'SI664615C', 'MHDBL000031'
         ]
         microhapulator.__main__.main(arglist)

--- a/microhapulator/tests/test_sim.py
+++ b/microhapulator/tests/test_sim.py
@@ -22,7 +22,7 @@ def test_main():
             'sim', '--panel', 'MHDBL000197', 'MHDBL000066', '--out', tempdir + '/reads.fastq',
             '--num-reads', '500', '--haploseq', tempdir + '/haplo.fasta',
             '--genotype', tempdir + '/genotype.bed', '--hap-seed', '293847',
-            '--seq-seed', '123454321', 'hg38.fasta', 'MHDBP000004'
+            '--seq-seed', '123454321', 'MHDBP000004'
         ]
         args = microhapulator.cli.parse_args(arglist)
         microhapulator.sim.main(args)
@@ -40,7 +40,7 @@ def test_main_no_haploseq():
         arglist = [
             'sim', '--panel', 'MHDBL000197', 'MHDBL000066', '--out', tempdir + '/reads.fastq',
             '--num-reads', '250', '--hap-seed', '1234', '--seq-seed', '5678',
-            '--seq-threads', '2', 'hg38.fasta', 'MHDBP000004',
+            '--seq-threads', '2', 'MHDBP000004',
         ]
         args = microhapulator.cli.parse_args(arglist)
         microhapulator.sim.main(args)
@@ -59,7 +59,7 @@ def test_main_relaxed(relaxed, testfile):
         arglist = [
             'sim', '--panel', 'MHDBL000013', 'MHDBL000212', 'MHDBL000197', '--num-reads', '100',
             '--hap-seed', '54321', '--seq-seed', '24680', '--out', tempdir + '/reads.fastq',
-            'hg38.fasta', 'MHDBP000003',
+            'MHDBP000003',
         ]
         args = microhapulator.cli.parse_args(arglist)
         args.relaxed = relaxed
@@ -74,7 +74,7 @@ def test_main_no_seeds():
     try:
         arglist = [
             'sim', '--panel', 'MHDBL000197', 'MHDBL000066', '--out', tempdir + '/reads.fastq',
-            '--num-reads', '200', '--seq-threads', '1', 'hg38.fasta', 'MHDBP000004',
+            '--num-reads', '200', '--seq-threads', '1', 'MHDBP000004',
         ]
         args = microhapulator.cli.parse_args(arglist)
         microhapulator.sim.main(args)
@@ -89,7 +89,7 @@ def test_main_bad_panel():
     with tempfile.NamedTemporaryFile(suffix='fq.gz') as outfile:
         arglist = [
             'sim', '--panel', 'DUUUUDE', 'SWEEEET', '--num-reads', '10',
-            '-o', outfile.name, 'hg38.fasta', 'MHDBP000004'
+            '-o', outfile.name, 'MHDBP000004'
         ]
         args = microhapulator.cli.parse_args(arglist)
         with pytest.raises(ValueError) as ve:

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,17 @@ setup(
     name='microhapulator',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    description='Simulator for microhaplotype sequences',
+    description='Software package for simulating and analyzing microhaplotype sequence data',
     long_description=longdesc,
     long_description_content_type='text/markdown',
-    url='https://github.com/bioforensics/microhapdb',
+    url='https://github.com/bioforensics/microhapulator',
     author='Daniel Standage',
     author_email='daniel.standage@nbacc.dhs.gov',
     packages=['microhapulator', 'microhapulator.cli', 'microhapulator.tests'],
     package_data={
         'microhapulator': [
-            'microhapulator/tests/data/*', 'microhapulator/tests/data/*/*'
+            'microhapulator/data/*', 'microhapulator/tests/data/*',
+            'microhapulator/tests/data/*/*'
         ]
     },
     include_package_data=True,
@@ -39,6 +40,7 @@ setup(
         'Framework :: IPython',
         'Framework :: Jupyter',
         'Intended Audience :: Science/Research',
+        'Intended Audience :: Legal Industry',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
         'Topic : Scientific/Engineering :: Bio-Informatics',


### PR DESCRIPTION
This update introduces a new module for downloading the human reference genome into a dedicated "package data" directory. This replaces the current sub-optimal behavior of requiring the user to have a specifically-named reference genome file in the current working directory.

By default `mhpl8r getrefr` will download the genome directly from UCSC, but it also supports "installing" a previously downloaded copy from a local file path.