### PR TITLE
BAM index check

### DIFF
--- a/microhapulator/cli/contrib.py
+++ b/microhapulator/cli/contrib.py
@@ -20,8 +20,8 @@ def subparser(subparsers):
         ' and `--bam` flags'
     )
     cli.add_argument(
-        '-r', '--refr', metavar='FILE', help='reference genome file in FASTA '
-        'format'
+        '-r', '--refr', metavar='FILE', help='microhap locus sequences in '
+        'Fasta format'
     )
     cli.add_argument(
         '-b', '--bam', metavar='FILE', help='aligned and sorted reads in BAM '

--- a/microhapulator/tests/data/three-contrib-log-link.bam
+++ b/microhapulator/tests/data/three-contrib-log-link.bam
@@ -1,0 +1,1 @@
+three-contrib-log.bam

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -10,6 +10,7 @@
 import json
 import microhapulator
 from microhapulator.tests import data_file
+from microhapulator.type import MissingBAMIndexError
 import pytest
 from tempfile import NamedTemporaryFile
 
@@ -22,6 +23,14 @@ def test_type_simple():
     testgt = microhapulator.genotype.ObservedGenotype(filename=testgtfile)
     assert gt.data == testgt.data
     assert gt.dump() == testgt.dump()
+
+
+def test_type_missing_bam_index():
+    bam = data_file('three-contrib-log-link.bam')
+    fasta = data_file('default-panel.fasta.gz')
+    with pytest.raises(MissingBAMIndexError) as ie:
+        gt = microhapulator.type.type(bam, fasta)
+    assert 'Please index' in str(ie)
 
 
 def test_type_cli_simple():


### PR DESCRIPTION
This update introduces a check for BAM indexes (required for pileups) and will now throw a more informative error if an index is missing. Also, CLI documentation for the `contrib` module was corrected. Closes #29.