### PR TITLE
Implement new `contain` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- New `contain` module for calculating the proportion of alleles from one sample present in another sample (see #41).
+- New `--dry-run` mode for `sim` and `mixture` modules (see #41).
+
+
 ## [0.3] 2019-06-06
 
 ### Added

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -20,6 +20,7 @@ from microhapulator import genotype
 from microhapulator import panel
 
 # Subcommands and command-line interface
+from microhapulator import contain
 from microhapulator import contrib
 from microhapulator import dist
 from microhapulator import getrefr

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -11,6 +11,7 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import microhapulator
 from sys import stderr
+from . import contain
 from . import contrib
 from . import dist
 from . import getrefr
@@ -20,6 +21,7 @@ from . import sim
 from . import type
 
 mains = {
+    'contain': microhapulator.contain.main,
     'contrib': microhapulator.contrib.main,
     'dist': microhapulator.dist.main,
     'getrefr': microhapulator.getrefr.main,
@@ -30,6 +32,7 @@ mains = {
 }
 
 subparser_funcs = {
+    'contain': contain.subparser,
     'contrib': contrib.subparser,
     'dist': dist.subparser,
     'getrefr': getrefr.subparser,

--- a/microhapulator/cli/contain.py
+++ b/microhapulator/cli/contain.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+def subparser(subparsers):
+    cli = subparsers.add_parser('contain')
+    cli.add_argument(
+        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
+        'default, output is written to the terminal (standard output)'
+    )
+    cli.add_argument(
+        'genotype1', help='simulated or inferred genotype in JSON format'
+    )
+    cli.add_argument(
+        'genotype2', help='simulated or inferred genotype in JSON format'
+    )

--- a/microhapulator/cli/mixture.py
+++ b/microhapulator/cli/mixture.py
@@ -52,6 +52,11 @@ def subparser(subparsers):
         'of threads to use when simulating targeted amplicon sequencing'
     )
     cli.add_argument(
+        '-y', '--dry-run', action='store_true', help='simulate genotype and '
+        'produce any requested outputs, but terminate prior to simulating '
+        'reads'
+    )
+    cli.add_argument(
         '-o', '--out', metavar='FILE', help='write simulated MiSeq reads in '
         'FASTQ format to FILE; by default, reads are written to terminal '
         '(standard output)'

--- a/microhapulator/cli/sim.py
+++ b/microhapulator/cli/sim.py
@@ -45,6 +45,11 @@ def subparser(subparsers):
     )
     outargs = cli.add_argument_group('Output configuration')
     outargs.add_argument(
+        '-y', '--dry-run', action='store_true', help='simulate genotype and '
+        'produce any requested outputs, but terminate prior to simulating '
+        'reads'
+    )
+    outargs.add_argument(
         '-o', '--out', metavar='FILE', help='write simulated MiSeq reads in '
         'FASTQ format to FILE; by default, reads are written to terminal '
         '(standard output)'

--- a/microhapulator/contain.py
+++ b/microhapulator/contain.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+from microhapulator.genotype import Genotype
+
+
+def contain(gt1, gt2):
+    '''Compute the proportion of alleles from gt2 present in gt1.'''
+    total = 0
+    contained = 0
+    for locus in gt2.loci():
+        allele1 = gt1.alleles(locus)
+        allele2 = gt2.alleles(locus)
+        total += len(allele2)
+        contained += len(allele2 & allele1)
+    return contained, total
+
+
+def main(args):
+    contained, total = contain(
+        Genotype(fromfile=args.genotype1),
+        Genotype(fromfile=args.genotype2)
+    )
+    data = {
+        'containment': round(contained / total, 4),
+        'contained_alleles': contained,
+        'total_alleles': total
+    }
+    with microhapulator.open(args.out, 'w') as fh:
+        json.dump(data, fh, indent=4)

--- a/microhapulator/mixture.py
+++ b/microhapulator/mixture.py
@@ -23,7 +23,7 @@ def calc_n_reads_from_proportions(n, totalreads, prop):
     return [int(totalreads * x) for x in normprop]
 
 
-def mixture(individuals, panel, relaxed=False, hapseeds=None, seqseeds=None,
+def mixture(individuals, panel, relaxed=False, hapseeds=None, dryrun=False, seqseeds=None,
             seqthreads=1, totalreads=1000000, proportions=None, gtfile=None):
     n = len(individuals)
     if hapseeds is None:
@@ -42,6 +42,9 @@ def mixture(individuals, panel, relaxed=False, hapseeds=None, seqseeds=None,
             genotypes.append(genotype)
         merged_genotype = microhapulator.genotype.SimulatedGenotype.merge(genotypes)
         merged_genotype.dump(gtfile)
+    if dryrun:
+        microhapulator.plog('[MicroHapulator::mixture] dry run requested, ditching out')
+        return
     numreads = calc_n_reads_from_proportions(n, totalreads, proportions)
     if 0 in numreads:
         raise ValueError('specified proportions result in 0 reads for 1 or more individuals')
@@ -65,8 +68,8 @@ def main(args=None):
         args = get_parser().parse_args()
     simulator = mixture(
         args.indiv, args.panel, relaxed=args.relaxed, hapseeds=args.hap_seeds,
-        seqseeds=args.seq_seeds, seqthreads=args.seq_threads, totalreads=args.num_reads,
-        proportions=args.proportions, gtfile=args.genotype,
+        dryrun=args.dry_run, seqseeds=args.seq_seeds, seqthreads=args.seq_threads,
+        totalreads=args.num_reads, proportions=args.proportions, gtfile=args.genotype,
     )
     with microhapulator.open(args.out, 'w') as fh:
         for n, defline, sequence, qualities in simulator:

--- a/microhapulator/sim.py
+++ b/microhapulator/sim.py
@@ -59,7 +59,7 @@ def simulate_genotype(popids, panel, hapseed=None, relaxed=False, outfile=None):
     return genotype
 
 
-def sim(popids, panel, relaxed=False, hapseed=None, gtfile=None, hapfile=None,
+def sim(popids, panel, relaxed=False, hapseed=None, gtfile=None, hapfile=None, dryrun=False,
         seqseed=None, seqthreads=2, numreads=500000, readsignature=None, readindex=0, debug=False):
     genotype = simulate_genotype(
         popids, panel, hapseed=hapseed, relaxed=relaxed, outfile=gtfile
@@ -71,6 +71,9 @@ def sim(popids, panel, relaxed=False, hapseed=None, gtfile=None, hapfile=None,
             print('>', defline, '\n', sequence, sep='', file=fh)
         fh.flush()
         fsync(fh.fileno())
+        if dryrun:
+            microhapulator.plog('[MicroHapulator::sim] dry run requested, ditching out')
+            return
         fqdir = mkdtemp()
         try:
             isscmd = [
@@ -112,8 +115,8 @@ def main(args=None):
         args = get_parser().parse_args()
     simulator = sim(
         args.popid, args.panel, relaxed=args.relaxed, hapseed=args.hap_seed,
-        gtfile=args.genotype, hapfile=args.haploseq, seqseed=args.seq_seed,
-        seqthreads=args.seq_threads, numreads=args.num_reads,
+        gtfile=args.genotype, hapfile=args.haploseq, dryrun=args.dry_run,
+        seqseed=args.seq_seed, seqthreads=args.seq_threads, numreads=args.num_reads,
     )
     with microhapulator.open(args.out, 'w') as fh:
         for n, defline, sequence, qualities in simulator:

--- a/microhapulator/tests/data/four-brits-sim.json
+++ b/microhapulator/tests/data/four-brits-sim.json
@@ -1,0 +1,799 @@
+{
+    "loci": {
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "C,A,C,C",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,G,C,T",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,T,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,A,G,T,T",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,A,G,C,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,A,A,T,T",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,A,T,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000048": {
+            "genotype": [
+                {
+                    "allele": "A,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,C,C",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,C,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,C,C",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "C,C,C",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,C,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,C,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "C,C,C,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "C,T,T,C",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "C,T,T,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000066": {
+            "genotype": [
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000074": {
+            "genotype": [
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,T,T",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,T,T",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000081": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,A,A,G",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,C,G,G,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,C,A,G,A",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,C,A,A,A",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,C,A,A,A",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,C,G,G,A",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,C,G,G,A",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000092": {
+            "genotype": [
+                {
+                    "allele": "G,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "G,G,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "C,A,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000105": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,A,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,T,A,C",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,T,A,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,C,A,T",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,T,A,C",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,C,G,C",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,T,A,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A,A",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "G,C,A,A,A",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,T,G,A,A",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,T,G,A,A",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "T,T,T,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,T,T,G",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,C,G,A",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "G,G,C,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000145": {
+            "genotype": [
+                {
+                    "allele": "A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000147": {
+            "genotype": [
+                {
+                    "allele": "A,A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,T,A,T",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,T,A,T",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000156": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "T,C,A,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "T,C,A,C",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "T,C,A,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000172": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,A,A",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "C,G,A,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "C,G,A,A",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "C,A,A,A",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000195": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,A,A",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "T,C,A,A",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "T,G,G,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "T,C,A,A",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "T,G,G,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,G,G,G",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000197": {
+            "genotype": [
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "A,A,T,A,T",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "T,T,A,T,C",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000204": {
+            "genotype": [
+                {
+                    "allele": "C,C,A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,G,C,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "T,T,A,G,C,C",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 7
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                },
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 2
+                },
+                {
+                    "allele": "G,T,C,A,C",
+                    "haplotype": 3
+                },
+                {
+                    "allele": "G,T,C,A,C",
+                    "haplotype": 4
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 5
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 6
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 7
+                }
+            ]
+        }
+    },
+    "ploidy": 8,
+    "type": "SimulatedGenotype",
+    "version": "0.3+0.g16e7f39.dirty"
+}

--- a/microhapulator/tests/data/one-american-sim.json
+++ b/microhapulator/tests/data/one-american-sim.json
@@ -1,0 +1,271 @@
+{
+    "loci": {
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000048": {
+            "genotype": [
+                {
+                    "allele": "A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000066": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000074": {
+            "genotype": [
+                {
+                    "allele": "T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000081": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,A,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000092": {
+            "genotype": [
+                {
+                    "allele": "C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000105": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000145": {
+            "genotype": [
+                {
+                    "allele": "A,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000147": {
+            "genotype": [
+                {
+                    "allele": "A,T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000156": {
+            "genotype": [
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000172": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000195": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000197": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000204": {
+            "genotype": [
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": null,
+    "type": "SimulatedGenotype",
+    "version": "0.3+0.g16e7f39.dirty"
+}

--- a/microhapulator/tests/data/one-brit-sim.json
+++ b/microhapulator/tests/data/one-brit-sim.json
@@ -1,0 +1,271 @@
+{
+    "loci": {
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000048": {
+            "genotype": [
+                {
+                    "allele": "A,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000066": {
+            "genotype": [
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000074": {
+            "genotype": [
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000081": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,A,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000092": {
+            "genotype": [
+                {
+                    "allele": "G,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000105": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000145": {
+            "genotype": [
+                {
+                    "allele": "A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000147": {
+            "genotype": [
+                {
+                    "allele": "A,A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000156": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000172": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000195": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000197": {
+            "genotype": [
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000204": {
+            "genotype": [
+                {
+                    "allele": "C,C,A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": null,
+    "type": "SimulatedGenotype",
+    "version": "0.3+0.g16e7f39.dirty"
+}

--- a/microhapulator/tests/data/one-italian-sim.json
+++ b/microhapulator/tests/data/one-italian-sim.json
@@ -1,0 +1,271 @@
+{
+    "loci": {
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000048": {
+            "genotype": [
+                {
+                    "allele": "C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000066": {
+            "genotype": [
+                {
+                    "allele": "G,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000074": {
+            "genotype": [
+                {
+                    "allele": "T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000081": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000092": {
+            "genotype": [
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000105": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000145": {
+            "genotype": [
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000147": {
+            "genotype": [
+                {
+                    "allele": "A,A,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000156": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000172": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000195": {
+            "genotype": [
+                {
+                    "allele": "T,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000197": {
+            "genotype": [
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000204": {
+            "genotype": [
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": null,
+    "type": "SimulatedGenotype",
+    "version": "0.3+4.g13368d1.dirty"
+}

--- a/microhapulator/tests/test_contain.py
+++ b/microhapulator/tests/test_contain.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+from microhapulator.tests import data_file
+import pytest
+from tempfile import NamedTemporaryFile
+
+
+@pytest.mark.parametrize('f1,f2,total,contained', [
+    ('four-brits-sim.json', 'one-brit-sim.json', 38, 38),
+    ('four-brits-sim.json', 'one-american-sim.json', 38, 31),
+    ('one-brit-sim.json', 'one-american-sim.json', 38, 11),
+])
+def test_contain(f1, f2, total, contained):
+    gt1 = microhapulator.genotype.Genotype(data_file(f1))
+    gt2 = microhapulator.genotype.Genotype(data_file(f2))
+    c, t = microhapulator.contain.contain(gt1, gt2)
+    assert t == total
+    assert c == contained

--- a/microhapulator/tests/test_contain.py
+++ b/microhapulator/tests/test_contain.py
@@ -25,3 +25,13 @@ def test_contain(f1, f2, total, contained):
     c, t = microhapulator.contain.contain(gt1, gt2)
     assert t == total
     assert c == contained
+
+
+def test_contain_cli(capsys):
+    arglist = [
+        'contain', data_file('one-brit-sim.json'), data_file('one-italian-sim.json')
+    ]
+    args = microhapulator.cli.parse_args(arglist)
+    microhapulator.contain.main(args)
+    terminal = capsys.readouterr()
+    assert '"containment": 0.4444' in terminal.out


### PR DESCRIPTION
This update implements a new `contain` module for calculating the proportion of alleles from one sample present in another sample. Closes #40. The update also introduces a `--dry-run` mode for the `sim` and `mixture` modules.