### PR TITLE
New `prob` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - New `contain` module for calculating the proportion of alleles from one sample present in another sample (see #41).
 - New `--dry-run` mode for `sim` and `mixture` modules (see #41).
+- New `prob` module for calculating likelihood ratio tests based on the random match probability (see #43).
 
 
 ## [0.3] 2019-06-06

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Invoke `mhpl8r <subcmd> --help` and replace `<subcmd>` with one of the
 subcommands listed below to see instructions for that operation.
 
 Subcommands:
-  subcmd             contain, contrib, dist, getrefr, mixture, refr, sim, type
+  subcmd             contain, contrib, dist, getrefr, mixture, prob, refr,
+                     sim, type
 
 Global arguments:
   -h, --help         show this help message and exit

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -25,6 +25,7 @@ from microhapulator import contrib
 from microhapulator import dist
 from microhapulator import getrefr
 from microhapulator import mixture
+from microhapulator import prob
 from microhapulator import refr
 from microhapulator import sim
 from microhapulator import type

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -16,6 +16,7 @@ from . import contrib
 from . import dist
 from . import getrefr
 from . import mixture
+from . import prob
 from . import refr
 from . import sim
 from . import type
@@ -26,6 +27,7 @@ mains = {
     'dist': microhapulator.dist.main,
     'getrefr': microhapulator.getrefr.main,
     'mixture': microhapulator.mixture.main,
+    'prob': microhapulator.prob.main,
     'refr': microhapulator.refr.main,
     'sim': microhapulator.sim.main,
     'type': microhapulator.type.main,
@@ -37,6 +39,7 @@ subparser_funcs = {
     'dist': dist.subparser,
     'getrefr': getrefr.subparser,
     'mixture': mixture.subparser,
+    'prob': prob.subparser,
     'refr': refr.subparser,
     'sim': sim.subparser,
     'type': type.subparser,

--- a/microhapulator/cli/prob.py
+++ b/microhapulator/cli/prob.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+def subparser(subparsers):
+    desc = (
+        'If a single genotype is provided, the random match probability of '
+        'the genotype is computed. If a pair of genotypes are provided, a '
+        'likelihood ratio test is performed comparing the likelihood that the '
+        'two genotypes are from the same individual versus the likelihood '
+        'that the two genotypes are from random unrelated individuals. The '
+        'genotype profiles are assumed to be identical, and differences '
+        'between the two profiles are assumed to be the result of genotyping '
+        'error. The test does not make sense for profiles with many allele '
+        'differences.'
+    )
+    cli = subparsers.add_parser('prob', description=desc)
+    cli.add_argument(
+        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
+        'default, output is written to the terminal (standard output)'
+    )
+    cli.add_argument(
+        'population', help='indicate which allele frequencies to use'
+    )
+    cli.add_argument(
+        'genotype1', help='genotype in JSON format'
+    )
+    cli.add_argument(
+        'genotype2', nargs='?', default=None, help='genotype in JSON format'
+    )

--- a/microhapulator/cli/prob.py
+++ b/microhapulator/cli/prob.py
@@ -22,6 +22,10 @@ def subparser(subparsers):
     )
     cli = subparsers.add_parser('prob', description=desc)
     cli.add_argument(
+        '-e', '--erate', type=float, metavar='ε', default=0.001, help='rate '
+        'at which errors in genotyping are expected; default is 0.001'
+    )
+    cli.add_argument(
         '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
         'default, output is written to the terminal (standard output)'
     )

--- a/microhapulator/genotype.py
+++ b/microhapulator/genotype.py
@@ -93,12 +93,15 @@ class Genotype(object):
                     assert len(result) == 1
                     frequency = list(result.Frequency)[0]
                 if frequency is None or frequency == 0.0:
-                    message = 'No population allele frequency data for '
+                    if frequency is None:
+                        message = 'No population allele frequency data for '
+                    else:
+                        message = 'Frequency=0.0 for '
                     message += 'allele "{:s}" at locus "{:s}" '.format(allele, locus)
                     message += 'for population "{:s}"; '.format(popid)
                     message += 'using RMP=0.001 for this allele'
                     microhapulator.plog('[MicroHapulator::genotype] WARNING:', message)
-                    prob *= 0.001  # No allele frequency data for this pop/allele combo
+                    prob *= 0.001
                 else:
                     prob *= frequency
         return prob

--- a/microhapulator/genotype.py
+++ b/microhapulator/genotype.py
@@ -73,6 +73,22 @@ class Genotype(object):
             )
         return set([a['allele'] for a in self.data['loci'][locusid]['genotype']])
 
+    def probability(self, popid):
+        """Compute the random match probability of this genotype."""
+        prob = 1.0
+        for locus in self.loci():
+            for allele in self.alleles(locus):
+                result = microhapdb.frequencies[
+                    (microhapdb.frequencies.Population == popid) &
+                    (microhapdb.frequencies.Locus == locus) &
+                    (microhapdb.frequencies.Allele == allele)
+                ]
+                if len(result) > 0:
+                    prob *= result.Frequency
+                else:
+                    prob *= 0.001  # No allele frequency data for this pop/allele combo
+        return prob
+
     def dump(self, outfile):
         if isinstance(outfile, str):
             with microhapulator.open(outfile, 'w') as fh:

--- a/microhapulator/prob.py
+++ b/microhapulator/prob.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+from microhapulator.genotype import Genotype
+
+
+def prob(popid, gt1, gt2=None):
+    if gt2 is None:
+        return gt1.rand_match_prob(popid)
+    else:
+        return gt1.rmp_lr_test(gt2, popid)
+
+
+def main(args):
+    gt1 = Genotype(fromfile=args.genotype1)
+    gt2 = Genotype(fromfile=args.genotype2) if args.genotype2 else None
+    result = prob(args.population, gt1, gt2)
+    key = 'random_match_probability' if gt2 is None else 'rmp_likelihood_ratio'
+    data = {
+        key: '{:.3E}'.format(result),
+    }
+    with microhapulator.open(args.out, 'w') as fh:
+        json.dump(data, fh, indent=4)

--- a/microhapulator/prob.py
+++ b/microhapulator/prob.py
@@ -12,17 +12,17 @@ import microhapulator
 from microhapulator.genotype import Genotype
 
 
-def prob(popid, gt1, gt2=None):
+def prob(popid, gt1, gt2=None, erate=0.001):
     if gt2 is None:
         return gt1.rand_match_prob(popid)
     else:
-        return gt1.rmp_lr_test(gt2, popid)
+        return gt1.rmp_lr_test(gt2, popid, erate=erate)
 
 
 def main(args):
     gt1 = Genotype(fromfile=args.genotype1)
     gt2 = Genotype(fromfile=args.genotype2) if args.genotype2 else None
-    result = prob(args.population, gt1, gt2)
+    result = prob(args.population, gt1, gt2=gt2, erate=args.erate)
     key = 'random_match_probability' if gt2 is None else 'rmp_likelihood_ratio'
     data = {
         key: '{:.3E}'.format(result),

--- a/microhapulator/tests/data/korea-5loc-1diff.json
+++ b/microhapulator/tests/data/korea-5loc-1diff.json
@@ -1,0 +1,66 @@
+{
+    "loci": {
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "C,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,G,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000172": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/korea-5loc-2diff-a.json
+++ b/microhapulator/tests/data/korea-5loc-2diff-a.json
@@ -15,7 +15,7 @@
         "MHDBL000018": {
             "genotype": [
                 {
-                    "allele": "T,G,C,T,G",
+                    "allele": "C,G,T,T,A",
                     "haplotype": 0
                 },
                 {
@@ -39,7 +39,7 @@
         "MHDBL000138": {
             "genotype": [
                 {
-                    "allele": "G,G,C,A",
+                    "allele": "A,A,C,A",
                     "haplotype": 0
                 },
                 {

--- a/microhapulator/tests/data/korea-5loc-2diff-b.json
+++ b/microhapulator/tests/data/korea-5loc-2diff-b.json
@@ -15,11 +15,11 @@
         "MHDBL000018": {
             "genotype": [
                 {
-                    "allele": "T,G,C,T,G",
+                    "allele": "C,G,T,T,A",
                     "haplotype": 0
                 },
                 {
-                    "allele": "T,G,C,T,G",
+                    "allele": "C,G,T,T,A",
                     "haplotype": 1
                 }
             ]

--- a/microhapulator/tests/data/korea-5loc-2diff-c.json
+++ b/microhapulator/tests/data/korea-5loc-2diff-c.json
@@ -15,11 +15,11 @@
         "MHDBL000018": {
             "genotype": [
                 {
-                    "allele": "T,G,C,T,G",
+                    "allele": "C,G,C,C,G",
                     "haplotype": 0
                 },
                 {
-                    "allele": "T,G,C,T,G",
+                    "allele": "C,G,T,T,A",
                     "haplotype": 1
                 }
             ]

--- a/microhapulator/tests/data/korea-5loc-missfreq.json
+++ b/microhapulator/tests/data/korea-5loc-missfreq.json
@@ -55,7 +55,7 @@
                     "haplotype": 0
                 },
                 {
-                    "allele": "C,G,G,G",
+                    "allele": "T,A,T,A",
                     "haplotype": 1
                 }
             ]

--- a/microhapulator/tests/data/korea-5loc-zerofreq.json
+++ b/microhapulator/tests/data/korea-5loc-zerofreq.json
@@ -3,7 +3,7 @@
         "MHDBL000017": {
             "genotype": [
                 {
-                    "allele": "T,A,G,C,T",
+                    "allele": "T,A,A,C,T",
                     "haplotype": 0
                 },
                 {

--- a/microhapulator/tests/data/korea-5loc.json
+++ b/microhapulator/tests/data/korea-5loc.json
@@ -1,0 +1,74 @@
+{
+    "loci": {
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "C,T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,G,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000172": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,G",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/test_prob.py
+++ b/microhapulator/tests/test_prob.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import microhapulator
+from microhapulator.tests import data_file
+import pytest
+
+
+def test_rmp():
+    gt = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc.json'))
+    assert gt.rand_match_prob('MHDBP000053') == pytest.approx(1.2122586342e-07)
+
+
+def test_rmp_lrt():
+    gt1 = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc.json'))
+    gt2 = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc-1diff.json'))
+    assert gt1.rmp_lr_test(gt1, 'MHDBP000053') == pytest.approx(8249064.776508)
+    assert gt1.rmp_lr_test(gt2, 'MHDBP000053') == pytest.approx(7424158.298857)
+
+
+def test_prob_cli_rmp(capsys):
+    arglist = [
+        'prob', 'MHDBP000053', data_file('korea-5loc.json')
+    ]
+    args = microhapulator.cli.parse_args(arglist)
+    microhapulator.prob.main(args)
+    terminal = capsys.readouterr()
+    assert '"random_match_probability": "1.212E-07"' in terminal.out
+
+
+def test_prob_cli_lrt(capsys):
+    arglist = [
+        'prob', 'MHDBP000053', data_file('korea-5loc.json'), data_file('korea-5loc-1diff.json')
+    ]
+    args = microhapulator.cli.parse_args(arglist)
+    microhapulator.prob.main(args)
+    terminal = capsys.readouterr()
+    assert '"rmp_likelihood_ratio": "7.424E+06"' in terminal.out

--- a/microhapulator/tests/test_prob.py
+++ b/microhapulator/tests/test_prob.py
@@ -14,14 +14,26 @@ import pytest
 
 def test_rmp():
     gt = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc.json'))
-    assert gt.rand_match_prob('MHDBP000053') == pytest.approx(1.2122586342e-07)
+    assert gt.rand_match_prob('MHDBP000053') == pytest.approx(9.30529727667e-10)
 
 
 def test_rmp_lrt():
     gt1 = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc.json'))
     gt2 = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc-1diff.json'))
-    assert gt1.rmp_lr_test(gt1, 'MHDBP000053') == pytest.approx(8249064.776508)
-    assert gt1.rmp_lr_test(gt2, 'MHDBP000053') == pytest.approx(7424158.298857)
+    assert gt1.rmp_lr_test(gt1, 'MHDBP000053') == pytest.approx(1074656693.1355)
+    assert gt1.rmp_lr_test(gt2, 'MHDBP000053') == pytest.approx(1074656.6931355)
+
+
+@pytest.mark.parametrize('altfile,lrvalue', [
+    ('korea-5loc-2diff-a.json', 1943.0058),
+    ('korea-5loc-2diff-b.json', 9624.2067),
+    ('korea-5loc-2diff-c.json', 34191.2606),
+])
+def test_rmp_lrt_2diff(altfile, lrvalue):
+    gt1 = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc.json'))
+    gt2 = microhapulator.genotype.Genotype(fromfile=data_file(altfile))
+    assert gt1.rmp_lr_test(gt2, 'MHDBP000053') == pytest.approx(1074.6567)
+    assert gt2.rmp_lr_test(gt1, 'MHDBP000053') == pytest.approx(lrvalue)
 
 
 def test_prob_cli_rmp(capsys):
@@ -31,7 +43,7 @@ def test_prob_cli_rmp(capsys):
     args = microhapulator.cli.parse_args(arglist)
     microhapulator.prob.main(args)
     terminal = capsys.readouterr()
-    assert '"random_match_probability": "1.212E-07"' in terminal.out
+    assert '"random_match_probability": "9.305E-10"' in terminal.out
 
 
 def test_prob_cli_lrt(capsys):
@@ -41,4 +53,14 @@ def test_prob_cli_lrt(capsys):
     args = microhapulator.cli.parse_args(arglist)
     microhapulator.prob.main(args)
     terminal = capsys.readouterr()
-    assert '"rmp_likelihood_ratio": "7.424E+06"' in terminal.out
+    assert '"rmp_likelihood_ratio": "1.075E+06"' in terminal.out
+
+
+def test_prob_zero_freq():
+    gt = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc-zerofreq.json'))
+    assert gt.rand_match_prob('MHDBP000053') == pytest.approx(2.963E-12)
+
+
+def test_prob_missing_freq():
+    gt = microhapulator.genotype.Genotype(fromfile=data_file('korea-5loc-missfreq.json'))
+    assert gt.rand_match_prob('MHDBP000053') == pytest.approx(4.898E-11)


### PR DESCRIPTION
This update includes new features for improved sample matching. Two new methods were added to the `genotype` class.

- `gt.rand_match_prob(pop)` calculates the random match probability of the genotype given the specified population allele frequencies
- `gt.rmp_lr_test(other, pop)` compares two genotypes and computes the likelihood ratio comparing two hypotheses: the hypothesis that the genotypes were derived the same individual, and the hypothesis that they were derived from two random unrelated individuals

These methods were exposed to the CLI via the new `prob` class. Closes #5.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)