### PR TITLE
New "unite" function/command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New `prob` module for calculating likelihood ratio tests based on the random match probability (see #43).
 - New `seq` module focused entirely on sequencing samples where genotypes have already been simulated (see #45).
 - New `mix` module for merging simulated genotypes into a simulated mixture sample (see #45).
+- New `unite` module for "mating" two genotypes to create a simulated "offspring" genotype (see #47).
 
 ### Changed
 - The `sim` module no longer performs simulated sequencing (now handled by new `seq` module) and instead focuses entirely on haplotype simulation (see #45).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ subcommands listed below to see instructions for that operation.
 
 Subcommands:
   subcmd             contain, contrib, dist, getrefr, mix, prob, refr, seq,
-                     sim, type
+                     sim, type, unite
 
 Global arguments:
   -h, --help         show this help message and exit

--- a/docs/DEVEL.md
+++ b/docs/DEVEL.md
@@ -37,3 +37,7 @@ make devhooks
 - in its dedicated module, each subcommand has a primary function matching the name of that subcommand
 - in its dedicated module, each subcommand has a function named `main` whose only purpose is to call the primary function and, if necessary, do file I/O
 - the intent of the previous two points is to maintain a Python API that closely matches the command-line interface; if someone invokes a command on the command line, it should be very easy for them to translate that into a Python API call
+
+There are a few exceptions to this rule, such as the `mix` and `unite` subcommands.
+These are accomplished by calling a single Python command and do not warrant a separate dedicated module.
+The `mhpl8r mix` command is simply a command-line interface to the `microhapulator.genotype.SimulatedGenotype.merge` function, while the `mhpl8r unite` command is an interface to the `microhapulator.genotype.Genotype.unite` function.

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -30,6 +30,7 @@ from microhapulator import refr
 from microhapulator import seq
 from microhapulator import sim
 from microhapulator import type
+from microhapulator import unite
 from microhapulator import __main__
 from microhapulator import cli
 

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -21,6 +21,7 @@ from . import refr
 from . import seq
 from . import sim
 from . import type
+from . import unite
 
 mains = {
     'contain': microhapulator.contain.main,
@@ -33,6 +34,7 @@ mains = {
     'seq': microhapulator.seq.main,
     'sim': microhapulator.sim.main,
     'type': microhapulator.type.main,
+    'unite': microhapulator.unite.main,
 }
 
 subparser_funcs = {
@@ -46,6 +48,7 @@ subparser_funcs = {
     'seq': seq.subparser,
     'sim': sim.subparser,
     'type': type.subparser,
+    'unite': unite.subparser,
 }
 
 

--- a/microhapulator/cli/unite.py
+++ b/microhapulator/cli/unite.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+def subparser(subparsers):
+    cli = subparsers.add_parser('unite')
+    cli.add_argument(
+        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
+        'default, output is written to the terminal (standard output)'
+    )
+    cli.add_argument(
+        '-s', '--seed', type=int, default=None, metavar='INT', help='seed for '
+        'random number generator'
+    )
+    cli.add_argument(
+        'mom', help='simulated or inferred genotype in JSON format'
+    )
+    cli.add_argument(
+        'dad', help='simulated or inferred genotype in JSON format'
+    )

--- a/microhapulator/tests/data/green-dad-1-gt.json
+++ b/microhapulator/tests/data/green-dad-1-gt.json
@@ -1,0 +1,642 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "C,G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "T,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "T,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/green-dad-2-gt.json
+++ b/microhapulator/tests/data/green-dad-2-gt.json
@@ -1,0 +1,642 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,A,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "A,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "T,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "C,C,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "A,T,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "C,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/green-dad-3-gt.json
+++ b/microhapulator/tests/data/green-dad-3-gt.json
@@ -1,0 +1,643 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,A,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "G,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "T,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype",
+    "version": "0.2+16.g4ca8f19.dirty"
+}

--- a/microhapulator/tests/data/green-kid-1-gt.json
+++ b/microhapulator/tests/data/green-kid-1-gt.json
@@ -1,0 +1,642 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "C,T,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "A,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "C,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/green-kid-2-gt.json
+++ b/microhapulator/tests/data/green-kid-2-gt.json
@@ -1,0 +1,642 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,C,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/green-kid-3-gt.json
+++ b/microhapulator/tests/data/green-kid-3-gt.json
@@ -1,0 +1,643 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "A,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "C,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype",
+    "version": "0.2+16.g4ca8f19.dirty"
+}

--- a/microhapulator/tests/data/green-mom-1-gt.json
+++ b/microhapulator/tests/data/green-mom-1-gt.json
@@ -1,0 +1,642 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "C,C,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/green-mom-2-gt.json
+++ b/microhapulator/tests/data/green-mom-2-gt.json
@@ -1,0 +1,642 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,C,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "A,T,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype"
+}

--- a/microhapulator/tests/data/green-mom-3-gt.json
+++ b/microhapulator/tests/data/green-mom-3-gt.json
@@ -1,0 +1,643 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "T,A,G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "T,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "T,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "C,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,A,T",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype",
+    "version": "0.2+16.g4ca8f19.dirty"
+}

--- a/microhapulator/tests/test_unite.py
+++ b/microhapulator/tests/test_unite.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import numpy.random
+import microhapulator
+from microhapulator.genotype import Genotype
+from microhapulator.tests import data_file
+import pytest
+
+
+@pytest.mark.parametrize('momgt,dadgt,kidgt,seed', [
+    ('green-mom-1-gt.json', 'green-dad-1-gt.json', 'green-kid-1-gt.json', 110517),
+    ('green-mom-2-gt.json', 'green-dad-2-gt.json', 'green-kid-2-gt.json', 111017),
+])
+def test_unite_basic(momgt, dadgt, kidgt, seed):
+    mom = Genotype(fromfile=data_file(momgt))
+    dad = Genotype(fromfile=data_file(dadgt))
+    kid = Genotype(fromfile=data_file(kidgt))
+    numpy.random.seed(seed)
+    test = Genotype.unite(mom, dad)
+    test.dump('BOOGER' + kidgt)
+    assert test == kid

--- a/microhapulator/tests/test_unite.py
+++ b/microhapulator/tests/test_unite.py
@@ -12,6 +12,7 @@ import microhapulator
 from microhapulator.genotype import Genotype
 from microhapulator.tests import data_file
 import pytest
+from tempfile import NamedTemporaryFile
 
 
 @pytest.mark.parametrize('momgt,dadgt,kidgt,seed', [
@@ -24,5 +25,17 @@ def test_unite_basic(momgt, dadgt, kidgt, seed):
     kid = Genotype(fromfile=data_file(kidgt))
     numpy.random.seed(seed)
     test = Genotype.unite(mom, dad)
-    test.dump('BOOGER' + kidgt)
     assert test == kid
+
+
+def test_unite_cli():
+    with NamedTemporaryFile(suffix='.json') as outfile:
+        arglist = [
+            'unite', '--seed', '113817', '--out', outfile.name,
+            data_file('green-mom-3-gt.json'), data_file('green-dad-3-gt.json'),
+        ]
+        args = microhapulator.cli.get_parser().parse_args(arglist)
+        microhapulator.unite.main(args)
+        gt = Genotype(fromfile=outfile.name)
+        testgt = Genotype(fromfile=data_file('green-kid-3-gt.json'))
+        assert gt == testgt

--- a/microhapulator/unite.py
+++ b/microhapulator/unite.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import numpy.random
+import microhapulator
+from microhapulator.genotype import Genotype
+
+
+def main(args):
+    if args.seed:
+        numpy.random.seed(args.seed)
+    gt = Genotype.unite(
+        Genotype(fromfile=args.mom),
+        Genotype(fromfile=args.dad),
+    )
+    with microhapulator.open(args.out, 'w') as fh:
+        gt.dump(fh)


### PR DESCRIPTION
This update introduces new functionality for "mating" two genotypes to create a simulated "offspring" genotype. At the Python level, this is invoked by calling the `microhapulator.genotype.Genotype.unite` function, and at the command-line level this is invoked by calling `mhpl8r unite` on two genotype files. Closes #42.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
