### PR TITLE
New diff module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New `seq` module focused entirely on sequencing samples where genotypes have already been simulated (see #45).
 - New `mix` module for merging simulated genotypes into a simulated mixture sample (see #45).
 - New `unite` module for "mating" two genotypes to create a simulated "offspring" genotype (see #47).
+- New `diff` modfule for showing the differences between two genotypes (see #58).
 
 ### Changed
 - The `sim` module no longer performs simulated sequencing (now handled by new `seq` module) and instead focuses entirely on haplotype simulation (see #45).

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Invoke `mhpl8r <subcmd> --help` and replace `<subcmd>` with one of the
 subcommands listed below to see instructions for that operation.
 
 Subcommands:
-  subcmd             contain, contrib, dist, getrefr, mix, prob, refr, seq,
-                     sim, type, unite
+  subcmd             contain, contrib, diff, dist, getrefr, mix, prob, refr,
+                     seq, sim, type, unite
 
 Global arguments:
   -h, --help         show this help message and exit

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -23,6 +23,7 @@ from microhapulator import panel
 from microhapulator import contain
 from microhapulator import contrib
 from microhapulator import dist
+from microhapulator import diff
 from microhapulator import getrefr
 from microhapulator import mix
 from microhapulator import prob

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -13,6 +13,7 @@ import microhapulator
 import sys
 from . import contain
 from . import contrib
+from . import diff
 from . import dist
 from . import getrefr
 from . import mix
@@ -26,6 +27,7 @@ from . import unite
 mains = {
     'contain': microhapulator.contain.main,
     'contrib': microhapulator.contrib.main,
+    'diff': microhapulator.diff.main,
     'dist': microhapulator.dist.main,
     'getrefr': microhapulator.getrefr.main,
     'mix': microhapulator.mix.main,
@@ -40,6 +42,7 @@ mains = {
 subparser_funcs = {
     'contain': contain.subparser,
     'contrib': contrib.subparser,
+    'diff': diff.subparser,
     'dist': dist.subparser,
     'getrefr': getrefr.subparser,
     'mix': mix.subparser,

--- a/microhapulator/cli/diff.py
+++ b/microhapulator/cli/diff.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+def subparser(subparsers):
+    cli = subparsers.add_parser('diff')
+    cli.add_argument(
+        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
+        'default, output is written to the terminal (standard output)'
+    )
+    cli.add_argument(
+        'genotype1', help='simulated or inferred genotype in JSON format'
+    )
+    cli.add_argument(
+        'genotype2', help='simulated or inferred genotype in JSON format'
+    )

--- a/microhapulator/diff.py
+++ b/microhapulator/diff.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+from microhapulator.genotype import Genotype
+
+
+def diff(gt1, gt2):
+    allloci = set(gt1.loci()).union(gt2.loci())
+    for locus in sorted(allloci):
+        allele1 = gt1.alleles(locus)
+        allele2 = gt2.alleles(locus)
+        diff1 = allele1 - allele2
+        diff2 = allele2 - allele1
+        if len(diff1) > 0 or len(diff2) > 2:
+            yield locus, diff1, diff2
+
+
+def main(args):
+    differ = diff(Genotype(fromfile=args.genotype1), Genotype(fromfile=args.genotype2))
+    with microhapulator.open(args.out, 'w') as fh:
+        for locus, diff1, diff2 in differ:
+            print(locus, file=fh)
+            if len(diff1) > 0:
+                print('>>>', ':'.join(sorted(diff1)), file=fh)
+            if len(diff2) > 0:
+                print('<<<', ':'.join(sorted(diff2)), file=fh)

--- a/microhapulator/tests/data/diff-comp-1-2.txt
+++ b/microhapulator/tests/data/diff-comp-1-2.txt
@@ -1,0 +1,6 @@
+MHDBL000140
+>>> C,C,A,A
+<<< C,C,T,A
+MHDBL000163
+>>> A,A,G,A,T
+<<< C,G,A,A,T

--- a/microhapulator/tests/data/diff-comp-1-3.txt
+++ b/microhapulator/tests/data/diff-comp-1-3.txt
@@ -1,0 +1,83 @@
+MHDBL000002
+>>> T,G,G,C
+<<< T,G,C,C
+MHDBL000007
+>>> T,T,G,G
+MHDBL000013
+>>> A,G,C,C
+MHDBL000017
+>>> A,A,G,C,T:T,A,A,T,T
+<<< T,G,G,C,C
+MHDBL000018
+>>> C,A,C,C,G
+<<< C,A,C,T,G:T,A,T,T,G
+MHDBL000030
+>>> A,C,C,C
+<<< A,A,T,C
+MHDBL000036
+>>> A,C,G:G,C,G
+<<< G,T,G
+MHDBL000038
+>>> T,A,A,T
+MHDBL000058
+>>> A,G,C,G:A,G,T,G
+<<< A,A,C,G:G,G,C,G
+MHDBL000076
+>>> G,T
+MHDBL000079
+>>> C,T
+<<< A,G
+MHDBL000082
+>>> A,C,T,T
+<<< G,C,T,T:G,T,A,T
+MHDBL000085
+>>> A,C,T,G:G,A,C,A
+<<< G,A,T,G:G,C,T,G
+MHDBL000101
+>>> C,C,C,T
+<<< T,C,C,C
+MHDBL000106
+>>> C,G,T,G
+<<< A,G,C,G
+MHDBL000111
+>>> G,C,A,A,G
+<<< A,C,A,A,A
+MHDBL000112
+>>> G,G,A,C
+MHDBL000122
+>>> T,G,C
+<<< G,A,C
+MHDBL000128
+>>> A,T,C,G
+<<< T,T,T,G
+MHDBL000129
+>>> G,T,C
+<<< G,T,A
+MHDBL000135
+>>> G,C,C:G,T,T
+<<< A,T,C
+MHDBL000138
+>>> A,A,C,A
+<<< G,A,C,G:G,G,C,G
+MHDBL000140
+>>> C,C,A,A
+<<< C,C,T,A
+MHDBL000144
+>>> A,G
+<<< G,G
+MHDBL000154
+>>> C,C
+<<< T,T
+MHDBL000163
+>>> A,A,G,A,T:C,A,G,A,T
+<<< C,G,A,A,T:C,G,G,G,T
+MHDBL000183
+>>> C,G:T,G
+<<< C,A:T,A
+MHDBL000210
+>>> A,T,T,G
+MHDBL000211
+>>> T,A,A
+<<< T,G,A
+MHDBL000212
+>>> G,C,C,C,T

--- a/microhapulator/tests/data/diff-comp-1.json
+++ b/microhapulator/tests/data/diff-comp-1.json
@@ -1,0 +1,648 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "G,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "HaploSeed": 4087746661,
+        "MaternalHaploPop": "MHDBP000052",
+        "PaternalHaploPop": "MHDBP000062"
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype",
+    "version": "0.2+25.gd50abdc.dirty"
+}

--- a/microhapulator/tests/data/diff-comp-2.json
+++ b/microhapulator/tests/data/diff-comp-2.json
@@ -1,0 +1,648 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "A,A,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,A,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,C,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "T,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "TG,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "A,G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "A,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "G,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "HaploSeed": 4087746661,
+        "MaternalHaploPop": "MHDBP000052",
+        "PaternalHaploPop": "MHDBP000062"
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype",
+    "version": "0.2+25.gd50abdc.dirty"
+}

--- a/microhapulator/tests/data/diff-comp-3.json
+++ b/microhapulator/tests/data/diff-comp-3.json
@@ -1,0 +1,648 @@
+{
+    "loci": {
+        "MHDBL000002": {
+            "genotype": [
+                {
+                    "allele": "T,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000003": {
+            "genotype": [
+                {
+                    "allele": "C,A,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,A,G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000007": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000013": {
+            "genotype": [
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000017": {
+            "genotype": [
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,G,G,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000018": {
+            "genotype": [
+                {
+                    "allele": "C,A,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,T,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000030": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000036": {
+            "genotype": [
+                {
+                    "allele": "G,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000038": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000042": {
+            "genotype": [
+                {
+                    "allele": "C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000047": {
+            "genotype": [
+                {
+                    "allele": "TG,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000058": {
+            "genotype": [
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000060": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000061": {
+            "genotype": [
+                {
+                    "allele": "A,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000069": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000076": {
+            "genotype": [
+                {
+                    "allele": "T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000079": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000082": {
+            "genotype": [
+                {
+                    "allele": "G,T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,T,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000085": {
+            "genotype": [
+                {
+                    "allele": "G,C,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000088": {
+            "genotype": [
+                {
+                    "allele": "C,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000090": {
+            "genotype": [
+                {
+                    "allele": "C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000098": {
+            "genotype": [
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000101": {
+            "genotype": [
+                {
+                    "allele": "T,C,C,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000106": {
+            "genotype": [
+                {
+                    "allele": "A,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000108": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000111": {
+            "genotype": [
+                {
+                    "allele": "G,C,A,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,A,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000112": {
+            "genotype": [
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G,A,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000117": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000122": {
+            "genotype": [
+                {
+                    "allele": "G,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000124": {
+            "genotype": [
+                {
+                    "allele": "G,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000126": {
+            "genotype": [
+                {
+                    "allele": "G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000128": {
+            "genotype": [
+                {
+                    "allele": "T,T,T,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,T,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000129": {
+            "genotype": [
+                {
+                    "allele": "G,T,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000131": {
+            "genotype": [
+                {
+                    "allele": "T,T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000132": {
+            "genotype": [
+                {
+                    "allele": "T,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000135": {
+            "genotype": [
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,T,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000136": {
+            "genotype": [
+                {
+                    "allele": "A,C,G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C,G,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000138": {
+            "genotype": [
+                {
+                    "allele": "G,G,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,A,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000140": {
+            "genotype": [
+                {
+                    "allele": "T,C,A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C,T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000144": {
+            "genotype": [
+                {
+                    "allele": "G,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000152": {
+            "genotype": [
+                {
+                    "allele": "A,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000154": {
+            "genotype": [
+                {
+                    "allele": "T,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000155": {
+            "genotype": [
+                {
+                    "allele": "A,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000163": {
+            "genotype": [
+                {
+                    "allele": "C,G,A,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,G,G,T",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000181": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000182": {
+            "genotype": [
+                {
+                    "allele": "A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000183": {
+            "genotype": [
+                {
+                    "allele": "C,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000192": {
+            "genotype": [
+                {
+                    "allele": "C,A,T",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "T,C,C",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000194": {
+            "genotype": [
+                {
+                    "allele": "G,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000196": {
+            "genotype": [
+                {
+                    "allele": "G,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "A,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000210": {
+            "genotype": [
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,T,C,G",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000211": {
+            "genotype": [
+                {
+                    "allele": "T,G,A",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "C,G,A",
+                    "haplotype": 1
+                }
+            ]
+        },
+        "MHDBL000212": {
+            "genotype": [
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 0
+                },
+                {
+                    "allele": "G,C,C,A,C",
+                    "haplotype": 1
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "HaploSeed": 3941839432,
+        "MaternalHaploPop": "MHDBP000052",
+        "PaternalHaploPop": "MHDBP000062"
+    },
+    "ploidy": 2,
+    "type": "SimulatedGenotype",
+    "version": "0.2+25.gd50abdc.dirty"
+}

--- a/microhapulator/tests/test_diff.py
+++ b/microhapulator/tests/test_diff.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapulator (github.com/bioforensics/microhapulator)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import json
+import microhapulator
+from microhapulator.tests import data_file
+import pytest
+from tempfile import NamedTemporaryFile
+
+
+def test_diff_basic():
+    gt1 = microhapulator.genotype.SimulatedGenotype(fromfile=data_file('diff-comp-1.json'))
+    gt2 = microhapulator.genotype.SimulatedGenotype(fromfile=data_file('diff-comp-2.json'))
+    diff = list(microhapulator.diff.diff(gt1, gt2))
+    assert diff == [
+        ('MHDBL000140', {'C,C,A,A'}, {'C,C,T,A'}),
+        ('MHDBL000163', {'A,A,G,A,T'}, {'C,G,A,A,T'}),
+    ]
+
+
+def test_diff_large():
+    gt1 = microhapulator.genotype.SimulatedGenotype(fromfile=data_file('diff-comp-1.json'))
+    gt2 = microhapulator.genotype.SimulatedGenotype(fromfile=data_file('diff-comp-3.json'))
+    diff = list(microhapulator.diff.diff(gt1, gt2))
+    loci = [d[0] for d in diff]
+    print(diff[9], diff[13], diff[16])
+    assert loci == [
+        'MHDBL000002', 'MHDBL000007', 'MHDBL000013', 'MHDBL000017', 'MHDBL000018', 'MHDBL000030',
+        'MHDBL000036', 'MHDBL000038', 'MHDBL000058', 'MHDBL000076', 'MHDBL000079', 'MHDBL000082',
+        'MHDBL000085', 'MHDBL000101', 'MHDBL000106', 'MHDBL000111', 'MHDBL000112', 'MHDBL000122',
+        'MHDBL000128', 'MHDBL000129', 'MHDBL000135', 'MHDBL000138', 'MHDBL000140', 'MHDBL000144',
+        'MHDBL000154', 'MHDBL000163', 'MHDBL000183', 'MHDBL000210', 'MHDBL000211', 'MHDBL000212'
+    ]
+    assert diff[9] == ('MHDBL000076', {'G,T'}, set())
+    assert diff[13] == ('MHDBL000101', {'C,C,C,T'}, {'T,C,C,C'})
+    assert diff[16] == ('MHDBL000112', {'G,G,A,C'}, set())
+
+
+def test_diff_cli():
+    f1 = data_file('diff-comp-1.json')
+    f2 = data_file('diff-comp-3.json')
+    with NamedTemporaryFile(suffix='.json') as outfile:
+        arglist = ['diff', '-o', outfile.name, f1, f2]
+        args = microhapulator.cli.get_parser().parse_args(arglist)
+        microhapulator.diff.main(args)
+        with microhapulator.open(outfile.name, 'r') as fh:
+            output = fh.read().strip()
+        with microhapulator.open(data_file('diff-comp-1-3.txt'), 'r') as fh:
+            testoutput = fh.read().strip()
+        assert output == testoutput


### PR DESCRIPTION
Much like the UNIX diff command shows the differences between two files, this update introduces the `diff` module for showing the differences between two genotypes. Closes #54.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
