### PR TITLE
Fix contrib API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Corrected a bug in the USA panel code ensuring that all loci have allele frequency data for all relevant populations (see #56).
+- Corrected a problem with the `contrib` API that prevented it from working directly on `Profile` objects (see #70).
 
 ### Removed
 - Dropped the `mixture` module, whose functionality is now covered by the more granular `sim`, `mix`, and `seq` modules (see #45).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Invoke `mhpl8r <subcmd> --help` and replace `<subcmd>` with one of the
 subcommands listed below to see instructions for that operation.
 
 Subcommands:
-  subcmd             contain, contrib, diff, dist, mix, prob, seq, sim, type, unite
+  subcmd             contain, contrib, diff, dist, mix, prob, seq, sim, type,
+                     unite
 
 Global arguments:
   -h, --help         show this help message and exit

--- a/microhapulator/contrib.py
+++ b/microhapulator/contrib.py
@@ -10,17 +10,22 @@
 import json
 from math import ceil
 import microhapulator
+from microhapulator.profile import Profile
 import sys
 
 
-def contrib(bamfile=None, refrfasta=None, pjson=None):
-    if not pjson and (not bamfile or not refrfasta):
+def load_profile(bamfile=None, refrfasta=None, json=None):
+    if not json and (not bamfile or not refrfasta):
         message = 'must provide either JSON profile or BAM and refr FASTA'
         raise ValueError(message)
-    if pjson:
-        profile = microhapulator.profile.Profile(fromfile=pjson)
+    if json:
+        profile = microhapulator.profile.Profile(fromfile=json)
     else:
         profile = microhapulator.type.type(bamfile, refrfasta)
+    return profile
+
+
+def contrib(profile):
     num_alleles_per_marker = [len(profile.alleles(marker)) for marker in profile.markers()]
     max_num_alleles = max(num_alleles_per_marker)
     max_thresh = max_num_alleles - 1 if max_num_alleles % 2 == 0 else max_num_alleles
@@ -30,7 +35,8 @@ def contrib(bamfile=None, refrfasta=None, pjson=None):
 
 
 def main(args):
-    ncontrib, nloci, ploci = contrib(bamfile=args.bam, refrfasta=args.refr, pjson=args.json)
+    profile = load_profile(bamfile=args.bam, refrfasta=args.refr, json=args.json)
+    ncontrib, nloci, ploci = contrib(profile)
     data = {
         'min_num_contrib': ncontrib,
         'num_loci_max_alleles': nloci,

--- a/microhapulator/tests/test_contrib.py
+++ b/microhapulator/tests/test_contrib.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------
 
 import microhapulator
+from microhapulator.profile import Profile
 from microhapulator.tests import data_file
 import pytest
 
@@ -21,14 +22,16 @@ import pytest
     ('three-contrib-log.json', 3),
 ])
 def test_contrib_json(pjson, numcontrib):
-    n, *data = microhapulator.contrib.contrib(pjson=data_file(pjson))
+    profile = Profile(fromfile=data_file(pjson))
+    n, *data = microhapulator.contrib.contrib(profile)
     assert n == numcontrib
 
 
 def test_contrib_bam():
     bam = data_file('three-contrib-log.bam')
     refr = data_file('default-panel.fasta.gz')
-    n, *data = microhapulator.contrib.contrib(bamfile=bam, refrfasta=refr)
+    profile = microhapulator.contrib.load_profile(bamfile=bam, refrfasta=refr)
+    n, *data = microhapulator.contrib.contrib(profile)
     assert n == 3
 
 
@@ -42,7 +45,9 @@ def test_contrib_main(capsys):
     assert '"min_num_contrib": 3' in out
 
 
-def test_no_op():
+def test_main_no_op():
+    arglist = ['contrib']
+    args = microhapulator.cli.get_parser().parse_args(arglist)
     pattern = r'must provide either JSON profile or BAM and refr FASTA'
     with pytest.raises(ValueError, match=pattern) as ve:
-        microhapulator.contrib.contrib()
+        microhapulator.contrib.main(args)

--- a/microhapulator/tests/test_contrib.py
+++ b/microhapulator/tests/test_contrib.py
@@ -22,7 +22,7 @@ import pytest
     ('three-contrib-log.json', 3),
 ])
 def test_contrib_json(pjson, numcontrib):
-    profile = Profile(fromfile=data_file(pjson))
+    profile = microhapulator.contrib.load_profile(json=data_file(pjson))
     n, *data = microhapulator.contrib.contrib(profile)
     assert n == numcontrib
 


### PR DESCRIPTION
While updating a demo of the Python API, I discovered that the `microhapulator.contrib.contrib` has no way of processing a `Profile` object already in memory. It could only take a JSON file or BAM/FASTA as input. This update fixes the API so that the `microhapulator.contrib.contrib` works *only* on `Profile` objects, and changes the CLI to accommodate all the requisite handling of input files.

----------

- [x] Changes are clearly described above
- <strike>Any relevant issue threads are referenced in the description</strike>
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
