### PR TITLE
Simplify `mhpl8r type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Moved panel definition code moved out of the core code and into dedicated notebooks (#74).
 - Replaced `MissingBAMIndexError` with BAM auto-indexing code (#78).
 - Improved read names and choice of interleaved or paired output for `mhpl8r seq` (#80).
+- Disable application of filtering thresholds by default in `mhpl8r type` (#82).
 
 ### Fixed
 - Corrected a bug with Fastq headers in `mhpl8r seq` module (see #71).

--- a/microhapulator/cli/contrib.py
+++ b/microhapulator/cli/contrib.py
@@ -27,3 +27,7 @@ def subparser(subparsers):
         '-b', '--bam', metavar='FILE', help='aligned and sorted reads in BAM '
         'format'
     )
+    cli.add_argument(
+        '-t', '--threshold', metavar='T', type=int, default=None,
+        help='threshold for inferring genotypes'
+    )

--- a/microhapulator/contrib.py
+++ b/microhapulator/contrib.py
@@ -14,14 +14,14 @@ from microhapulator.profile import Profile
 import sys
 
 
-def load_profile(bamfile=None, refrfasta=None, json=None):
+def load_profile(bamfile=None, refrfasta=None, json=None, threshold=None):
     if not json and (not bamfile or not refrfasta):
         message = 'must provide either JSON profile or BAM and refr FASTA'
         raise ValueError(message)
     if json:
         profile = microhapulator.profile.Profile(fromfile=json)
     else:
-        profile = microhapulator.type.type(bamfile, refrfasta)
+        profile = microhapulator.type.type(bamfile, refrfasta, threshold=threshold)
     return profile
 
 
@@ -35,7 +35,9 @@ def contrib(profile):
 
 
 def main(args):
-    profile = load_profile(bamfile=args.bam, refrfasta=args.refr, json=args.json)
+    profile = load_profile(
+        bamfile=args.bam, refrfasta=args.refr, json=args.json, threshold=args.threshold
+    )
     ncontrib, nloci, ploci = contrib(profile)
     data = {
         'min_num_contrib': ncontrib,

--- a/microhapulator/tests/data/pashtun-sim/test-output-sans-genotype.json
+++ b/microhapulator/tests/data/pashtun-sim/test-output-sans-genotype.json
@@ -1,0 +1,45 @@
+{
+    "markers": {
+        "mh13KK-218": {
+            "allele_counts": {
+                "G,T,C,T": 1,
+                "T,G,C,T": 1,
+                "T,G,T,T": 2,
+                "T,T,A,T": 2,
+                "T,T,C,A": 1,
+                "T,T,C,C": 1,
+                "T,T,C,G": 1,
+                "T,T,C,T": 1048,
+                "T,T,T,G": 2,
+                "T,T,T,T": 1028
+            },
+            "genotype": [],
+            "max_coverage": 2500,
+            "mean_coverage": 2152.9,
+            "min_coverage": 45,
+            "num_discarded_reads": 413
+        },
+        "mh21KK-320": {
+            "allele_counts": {
+                "G,A,C,A": 1,
+                "G,A,G,A": 2,
+                "G,A,T,A": 923,
+                "G,A,T,G": 1,
+                "G,G,A,A": 1,
+                "G,G,C,A": 933,
+                "G,G,C,G": 3,
+                "G,G,C,T": 3,
+                "G,G,T,A": 2,
+                "T,G,C,A": 1
+            },
+            "genotype": [],
+            "max_coverage": 2500,
+            "mean_coverage": 2153.0,
+            "min_coverage": 33,
+            "num_discarded_reads": 627
+        }
+    },
+    "ploidy": null,
+    "type": "ObservedProfile",
+    "version": "0.4.1+26.gf268e39.dirty"
+}

--- a/microhapulator/tests/test_contrib.py
+++ b/microhapulator/tests/test_contrib.py
@@ -30,7 +30,7 @@ def test_contrib_json(pjson, numcontrib):
 def test_contrib_bam():
     bam = data_file('three-contrib-log.bam')
     refr = data_file('default-panel.fasta.gz')
-    profile = microhapulator.contrib.load_profile(bamfile=bam, refrfasta=refr)
+    profile = microhapulator.contrib.load_profile(bamfile=bam, refrfasta=refr, threshold=10)
     n, *data = microhapulator.contrib.contrib(profile)
     assert n == 3
 
@@ -38,7 +38,7 @@ def test_contrib_bam():
 def test_contrib_main(capsys):
     bam = data_file('three-contrib-log.bam')
     refr = data_file('default-panel.fasta.gz')
-    arglist = ['contrib', '-b', bam, '-r', refr]
+    arglist = ['contrib', '-b', bam, '-r', refr, '-t', '10']
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.contrib.main(args)
     out, err = capsys.readouterr()

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -25,6 +25,15 @@ def test_type_simple():
     assert gt == testgt
 
 
+def test_type_simpler():
+    bam = data_file('pashtun-sim/aligned-reads.bam')
+    fasta = data_file('pashtun-sim/tiny-panel.fasta.gz')
+    gt = microhapulator.type.type(bam, fasta)
+    testgtfile = data_file('pashtun-sim/test-output-sans-genotype.json')
+    testgt = ObservedProfile(fromfile=testgtfile)
+    assert gt == testgt
+
+
 def test_type_missing_bam_index(tmp_path):
     bam = data_file('three-contrib-log-link.bam')
     fasta = data_file('default-panel.fasta.gz')

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -19,7 +19,7 @@ from tempfile import NamedTemporaryFile
 def test_type_simple():
     bam = data_file('pashtun-sim/aligned-reads.bam')
     fasta = data_file('pashtun-sim/tiny-panel.fasta.gz')
-    gt = microhapulator.type.type(bam, fasta)
+    gt = microhapulator.type.type(bam, fasta, threshold=10)
     testgtfile = data_file('pashtun-sim/test-output.json')
     testgt = ObservedProfile(fromfile=testgtfile)
     assert gt == testgt
@@ -58,7 +58,7 @@ def test_type_dyn_cutoff():
     bam = data_file('dyncut-test-reads.bam')
     fasta = data_file('dyncut-panel.fasta.gz')
 
-    gt = microhapulator.type.type(bam, fasta)
+    gt = microhapulator.type.type(bam, fasta, threshold=10)
     assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G'])
     assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
 

--- a/microhapulator/type.py
+++ b/microhapulator/type.py
@@ -76,14 +76,17 @@ def tally_haplotypes(bamfile, refrfasta):
     )
 
 
-def type(bamfile, refrfasta, threshold=10):
+def type(bamfile, refrfasta, threshold=None):
     genotyper = tally_haplotypes(bamfile, refrfasta)
     profile = microhapulator.profile.ObservedProfile()
     for locusid, cov_by_pos, htcounts, ndiscarded in genotyper:
         profile.record_coverage(locusid, cov_by_pos, ndiscarded=ndiscarded)
         for allele, count in htcounts.items():
             profile.record_allele(locusid, allele, count)
-    profile.infer(threshold=threshold)
+        if threshold is None:
+            profile.data['markers'][locusid]['genotype'] = list()
+    if threshold is not None:
+        profile.infer(threshold=threshold)
     return profile
 
 


### PR DESCRIPTION
The thresholds used currently for genotype calling are not well thought out or tested. This PR disables them by default for now, though they can still be activated when needed (i.e. to make legacy tests still pass). Looking forward, it may make sense to delegate the thresholds to a dedicated program before e.g. analysis with probgen software.

----------

- [x] Changes are clearly described above
- ~Any relevant issue threads are referenced in the description~
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
