### PR TITLE
Update typing thresholds and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+- New `--base-qual` parameter for `mhpl8r type` to set the minimum required base quality when iterating over reads in a pileup (#83).
+
 ### Changed
 - Updated mybinder demo (see #69).
 - Simulated Illumina sequencing now uses 1 thread by default, which paradoxically should lead to better performance (#71).
 - Moved panel definition code moved out of the core code and into dedicated notebooks (#74).
 - Replaced `MissingBAMIndexError` with BAM auto-indexing code (#78).
 - Improved read names and choice of interleaved or paired output for `mhpl8r seq` (#80).
-- Disable application of filtering thresholds by default in `mhpl8r type` (#82).
+- Replaced `--threshold` with `--static` and `--dynamic` in in `mhpl8r type`, disabled both by default (#82, #83).
 
 ### Fixed
 - Corrected a bug with Fastq headers in `mhpl8r seq` module (see #71).

--- a/microhapulator/cli/contrib.py
+++ b/microhapulator/cli/contrib.py
@@ -28,6 +28,10 @@ def subparser(subparsers):
         'format'
     )
     cli.add_argument(
-        '-t', '--threshold', metavar='T', type=int, default=None,
-        help='threshold for inferring genotypes'
+        '-s', '--static', metavar='ST', type=int, default=None,
+        help='apply a static threshold for calling genotypes; see `mhpl8r type --help`'
+    )
+    cli.add_argument(
+        '-d', '--dynamic', metavar='DT', type=float, default=None,
+        help='apply a dynamic threshold for calling genotypes; see `mhpl8r type --help`'
     )

--- a/microhapulator/cli/type.py
+++ b/microhapulator/cli/type.py
@@ -17,6 +17,11 @@ def subparser(subparsers):
         'default, output is written to the terminal (standard output)'
     )
     cli.add_argument(
+        '-b', '--base-qual', metavar='B', type=int, default=10,
+        help='minimum base quality required for haplotype calling; by default B=10, '
+        'corresponding to Q10, i.e., 90%% probability that base call is correct'
+    )
+    cli.add_argument(
         '-e', '--effcov', metavar='EC', type=float, default=0.25,
         help='only reads that span all SNPs in a microhaplotype are retained, all others are '
         'discarded; if most of the reads related to a marker are discarded, it has low *effective '

--- a/microhapulator/cli/type.py
+++ b/microhapulator/cli/type.py
@@ -17,14 +17,29 @@ def subparser(subparsers):
         'default, output is written to the terminal (standard output)'
     )
     cli.add_argument(
-        '-t', '--threshold', metavar='T', type=int, default=8,
-        help='coverage threshold below which alleles will be ignored at loci with low effective '
-        'coverage (discarded reads are > 75%% of total reads); by default T=10; this is used to '
-        'distinguish true alleles from sequencing error induced alleles; the threshold is '
-        'computed automatically at loci with high effective coverage'
+        '-e', '--effcov', metavar='EC', type=float, default=0.25,
+        help='only reads that span all SNPs in a microhaplotype are retained, all others are '
+        'discarded; if most of the reads related to a marker are discarded, it has low *effective '
+        'coverage*; this parameter sets that threshold, i.e., if the fraction of retained reads '
+        'is < EC it is considered low effective coverage; by default EC=0.25 (or 25%%)'
     )
     cli.add_argument(
-        'refr', help='microhap locus sequences in Fasta format'
+        '-s', '--static', metavar='ST', type=int, default=None,
+        help='apply a static threshold for calling genotypes, i.e., discard any haplotype whose '
+        'count is less than ST; by default, ST is undefined, the static filter is not applied, '
+        'and only raw haplotype counts are reported, not genotype calls; if --dynamic is also '
+        'defined, --static is only applied to markers with low effective coverage'
+    )
+    cli.add_argument(
+        '-d', '--dynamic', metavar='DT', type=float, default=None,
+        help='apply a dynamic threshold for calling genotypes, i.e., if AC is the average count '
+        'of all haplotypes observed at the marker, discard any haplotypes whose count is less '
+        'than DT * AC; by default, DT is undefined, the dynamic filter is not applied, and only '
+        'raw haplotype counts are reported, not genotype calls; if --static is also defined, '
+        '--dynamic is only applied to markers with high effective coverage'
+    )
+    cli.add_argument(
+        'refr', help='microhap marker sequences in Fasta format'
     )
     cli.add_argument(
         'bam', help='aligned and sorted reads in BAM format'

--- a/microhapulator/contrib.py
+++ b/microhapulator/contrib.py
@@ -14,14 +14,14 @@ from microhapulator.profile import Profile
 import sys
 
 
-def load_profile(bamfile=None, refrfasta=None, json=None, threshold=None):
+def load_profile(bamfile=None, refrfasta=None, json=None, **kwargs):
     if not json and (not bamfile or not refrfasta):
         message = 'must provide either JSON profile or BAM and refr FASTA'
         raise ValueError(message)
     if json:
         profile = microhapulator.profile.Profile(fromfile=json)
     else:
-        profile = microhapulator.type.type(bamfile, refrfasta, threshold=threshold)
+        profile = microhapulator.type.type(bamfile, refrfasta, **kwargs)
     return profile
 
 
@@ -36,7 +36,8 @@ def contrib(profile):
 
 def main(args):
     profile = load_profile(
-        bamfile=args.bam, refrfasta=args.refr, json=args.json, threshold=args.threshold
+        bamfile=args.bam, refrfasta=args.refr, json=args.json, static=args.static,
+        dynamic=args.dynamic
     )
     ncontrib, nloci, ploci = contrib(profile)
     data = {

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -328,17 +328,18 @@ class ObservedProfile(Profile):
                 self.data['markers'][marker]['genotype'] = list()
                 continue
             gt = set()
-            for allele, count in mdata['allele_counts'].items():
-                if dynamic is None or eff_cov < ecthreshold:
+            allelecounts = mdata['allele_counts']
+            for allele, count in allelecounts.items():
+                eff_cov = 1.0 - (mdata['num_discarded_reads'] / mdata['max_coverage'])
+                if dynamic is None or (static is not None and eff_cov < ecthreshold):
                     # Use static cutoff (low effective coverage, or dynamic cutoff undefined)
                     if count < static:
                         continue
                 else:
                     # Use dynamic cutoff (high effective coverage, or static cutoff undefined)
-                    eff_cov = 1.0 - (mdata['num_discarded_reads'] / mdata['max_coverage'])
-                    avgcount = 0.0
-                    if len(allelecounts.values()) > 0:
-                        avgcount = sum(allelecounts.values()) / len(allelecounts.values())
+                    if len(allelecounts.values()) == 0:
+                        continue
+                    avgcount = sum(allelecounts.values()) / len(allelecounts.values())
                     if count < avgcount * dynamic:
                         continue
                 gt.add(allele)

--- a/microhapulator/tests/test_contrib.py
+++ b/microhapulator/tests/test_contrib.py
@@ -30,7 +30,9 @@ def test_contrib_json(pjson, numcontrib):
 def test_contrib_bam():
     bam = data_file('three-contrib-log.bam')
     refr = data_file('default-panel.fasta.gz')
-    profile = microhapulator.contrib.load_profile(bamfile=bam, refrfasta=refr, threshold=10)
+    profile = microhapulator.contrib.load_profile(
+        bamfile=bam, refrfasta=refr, dynamic=0.25, static=10
+    )
     n, *data = microhapulator.contrib.contrib(profile)
     assert n == 3
 
@@ -38,7 +40,7 @@ def test_contrib_bam():
 def test_contrib_main(capsys):
     bam = data_file('three-contrib-log.bam')
     refr = data_file('default-panel.fasta.gz')
-    arglist = ['contrib', '-b', bam, '-r', refr, '-t', '10']
+    arglist = ['contrib', '-b', bam, '-r', refr, '--static', '10', '--dynamic', '0.25']
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.contrib.main(args)
     out, err = capsys.readouterr()

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -19,7 +19,7 @@ from tempfile import NamedTemporaryFile
 def test_type_simple():
     bam = data_file('pashtun-sim/aligned-reads.bam')
     fasta = data_file('pashtun-sim/tiny-panel.fasta.gz')
-    gt = microhapulator.type.type(bam, fasta, static=10)
+    gt = microhapulator.type.type(bam, fasta, static=10, dynamic=0.25)
     testgtfile = data_file('pashtun-sim/test-output.json')
     testgt = ObservedProfile(fromfile=testgtfile)
     assert gt == testgt
@@ -41,7 +41,7 @@ def test_type_missing_bam_index(tmp_path):
     tmp_fasta = str(tmp_path / 'default-panel.fasta.gz')
     copyfile(bam, tmp_bam)
     copyfile(fasta, tmp_fasta)
-    gt = microhapulator.type.type(tmp_bam, tmp_fasta)
+    gt = microhapulator.type.type(tmp_bam, tmp_fasta, minbasequal=13)
     ac30 = gt.data['markers']['MHDBL000030']['allele_counts']
     ac197 = gt.data['markers']['MHDBL000197']['allele_counts']
     assert ac30 == {'A,A,T,C': 3, 'A,C,C,C': 2, 'A,C,C,G': 18, 'G,C,C,C': 1, 'G,C,C,G': 34}
@@ -51,7 +51,7 @@ def test_type_missing_bam_index(tmp_path):
 def test_type_cli_simple():
     with NamedTemporaryFile() as outfile:
         arglist = [
-            'type', '--out', outfile.name, '--static', '5',
+            'type', '--out', outfile.name, '--static', '5', '--dynamic', '0.25',
             data_file('pashtun-sim/tiny-panel.fasta.gz'),
             data_file('pashtun-sim/aligned-reads.bam'),
         ]
@@ -67,11 +67,11 @@ def test_type_dyn_cutoff():
     bam = data_file('dyncut-test-reads.bam')
     fasta = data_file('dyncut-panel.fasta.gz')
 
-    gt = microhapulator.type.type(bam, fasta, static=10)
+    gt = microhapulator.type.type(bam, fasta, static=10, dynamic=0.25)
     assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G'])
     assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
 
-    gt = microhapulator.type.type(bam, fasta, static=4)
+    gt = microhapulator.type.type(bam, fasta, static=4, dynamic=0.25)
     assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G', 'C,A,C,T,A', 'T,G,C,T,A'])
     assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
 

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -19,7 +19,7 @@ from tempfile import NamedTemporaryFile
 def test_type_simple():
     bam = data_file('pashtun-sim/aligned-reads.bam')
     fasta = data_file('pashtun-sim/tiny-panel.fasta.gz')
-    gt = microhapulator.type.type(bam, fasta, threshold=10)
+    gt = microhapulator.type.type(bam, fasta, static=10)
     testgtfile = data_file('pashtun-sim/test-output.json')
     testgt = ObservedProfile(fromfile=testgtfile)
     assert gt == testgt
@@ -51,7 +51,7 @@ def test_type_missing_bam_index(tmp_path):
 def test_type_cli_simple():
     with NamedTemporaryFile() as outfile:
         arglist = [
-            'type', '--out', outfile.name, '--threshold', '5',
+            'type', '--out', outfile.name, '--static', '5',
             data_file('pashtun-sim/tiny-panel.fasta.gz'),
             data_file('pashtun-sim/aligned-reads.bam'),
         ]
@@ -67,11 +67,11 @@ def test_type_dyn_cutoff():
     bam = data_file('dyncut-test-reads.bam')
     fasta = data_file('dyncut-panel.fasta.gz')
 
-    gt = microhapulator.type.type(bam, fasta, threshold=10)
+    gt = microhapulator.type.type(bam, fasta, static=10)
     assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G'])
     assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
 
-    gt = microhapulator.type.type(bam, fasta, threshold=4)
+    gt = microhapulator.type.type(bam, fasta, static=4)
     assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G', 'C,A,C,T,A', 'T,G,C,T,A'])
     assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
 

--- a/microhapulator/type.py
+++ b/microhapulator/type.py
@@ -39,7 +39,7 @@ def check_index(bamfile):
         pysam.index(bamfile)
 
 
-def tally_haplotypes(bamfile, refrfasta):
+def tally_haplotypes(bamfile, refrfasta, minbasequal=10):
     totaldiscarded = 0
     with microhapulator.open(refrfasta, 'r') as fh:
         offsets = parse_variant_offsets_from_fasta_headers(fh)
@@ -51,7 +51,7 @@ def tally_haplotypes(bamfile, refrfasta):
         ht = defaultdict(dict)
         varloc = set(offsets[locusid])
         cov_pos = list()
-        for column in bam.pileup(locusid):
+        for column in bam.pileup(locusid, min_base_quality=minbasequal):
             cov_pos.append(column.n)
             if column.pos not in varloc:
                 continue
@@ -76,8 +76,8 @@ def tally_haplotypes(bamfile, refrfasta):
     )
 
 
-def type(bamfile, refrfasta, ecthreshold=0.25, static=None, dynamic=None):
-    genotyper = tally_haplotypes(bamfile, refrfasta)
+def type(bamfile, refrfasta, minbasequal=10, ecthreshold=0.25, static=None, dynamic=None):
+    genotyper = tally_haplotypes(bamfile, refrfasta, minbasequal=minbasequal)
     profile = microhapulator.profile.ObservedProfile()
     for locusid, cov_by_pos, htcounts, ndiscarded in genotyper:
         profile.record_coverage(locusid, cov_by_pos, ndiscarded=ndiscarded)
@@ -89,6 +89,7 @@ def type(bamfile, refrfasta, ecthreshold=0.25, static=None, dynamic=None):
 
 def main(args):
     profile = type(
-        args.bam, args.refr, ecthreshold=args.effcov, static=args.static, dynamic=args.dynamic
+        args.bam, args.refr, minbasequal=args.base_qual, ecthreshold=args.effcov,
+        static=args.static, dynamic=args.dynamic
     )
     profile.dump(args.out)

--- a/microhapulator/type.py
+++ b/microhapulator/type.py
@@ -76,20 +76,19 @@ def tally_haplotypes(bamfile, refrfasta):
     )
 
 
-def type(bamfile, refrfasta, threshold=None):
+def type(bamfile, refrfasta, ecthreshold=0.25, static=None, dynamic=None):
     genotyper = tally_haplotypes(bamfile, refrfasta)
     profile = microhapulator.profile.ObservedProfile()
     for locusid, cov_by_pos, htcounts, ndiscarded in genotyper:
         profile.record_coverage(locusid, cov_by_pos, ndiscarded=ndiscarded)
         for allele, count in htcounts.items():
             profile.record_allele(locusid, allele, count)
-        if threshold is None:
-            profile.data['markers'][locusid]['genotype'] = list()
-    if threshold is not None:
-        profile.infer(threshold=threshold)
+    profile.infer(ecthreshold=ecthreshold, static=static, dynamic=dynamic)
     return profile
 
 
 def main(args):
-    profile = type(args.bam, args.refr, threshold=args.threshold)
+    profile = type(
+        args.bam, args.refr, ecthreshold=args.effcov, static=args.static, dynamic=args.dynamic
+    )
     profile.dump(args.out)


### PR DESCRIPTION
The naïve thresholds implemented by MicroHapulator differ from the kinds of thresholds commonly used for forensic analysis. At some point I want to implement detection thresholds and analytical thresholds. But at the moment, this PR replaces the `--threshold` parameter for `mhpl8r type` with `--static`, `--dynamic`, and `--effcov` parameters to allow more finer tuning of the thresholds.

Also, a new `--base-qual` parameter was added with a default of 10 (Q10 = 90% probability of correct base call), replacing the default of 13 used by pysam when iterating over reads in a pileup.

----------

- [x] Changes are clearly described above
- ~Any relevant issue threads are referenced in the description~
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [ ] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
