### PR TITLE
Extend max depth threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Replaced `MissingBAMIndexError` with BAM auto-indexing code (#78).
 - Improved read names and choice of interleaved or paired output for `mhpl8r seq` (#80).
 - Replaced `--threshold` with `--static` and `--dynamic` in in `mhpl8r type`, disabled both by default (#82, #83).
+- Changed the default pysam pileup `max_depth` parameter, overriding 8000 with 1e6 and exposing as a hidden CLI parameter (#87).
 
 ### Fixed
-- Corrected a bug with Fastq headers in `mhpl8r seq` module (see #71).
-- Corrected a bug resulting from attempting to do set operations on `None` (see #75).
-- Corrected a bug with RMP implementation (see #86).
+- Corrected a bug with Fastq headers in `mhpl8r seq` module (#71).
+- Corrected a bug resulting from attempting to do set operations on `None` (#75).
+- Corrected a bug with RMP implementation (#86).
 
 ## [0.4] 2019-11-05
 

--- a/microhapulator/cli/type.py
+++ b/microhapulator/cli/type.py
@@ -7,6 +7,7 @@
 # and is licensed under the BSD license: see LICENSE.txt.
 # -----------------------------------------------------------------------------
 
+from argparse import SUPPRESS
 import sys
 
 
@@ -43,9 +44,6 @@ def subparser(subparsers):
         'raw haplotype counts are reported, not genotype calls; if --static is also defined, '
         '--dynamic is only applied to markers with high effective coverage'
     )
-    cli.add_argument(
-        'refr', help='microhap marker sequences in Fasta format'
-    )
-    cli.add_argument(
-        'bam', help='aligned and sorted reads in BAM format'
-    )
+    cli.add_argument('-m', '--max-depth', metavar='M', type=float, default=1e6, help=SUPPRESS)
+    cli.add_argument('refr', help='microhap marker sequences in Fasta format')
+    cli.add_argument('bam', help='aligned and sorted reads in BAM format')


### PR DESCRIPTION
By default, pysam limits pileups to 8000 reads max depth. This update overrides that default with 1000000, and exposes the parameter to the CLI.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [ ] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
