### PR TITLE
Format code with Black

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test4:
 devdeps:
 	pip install --upgrade pip setuptools
 	pip install wheel twine
-	pip install pycodestyle 'pytest>=5.0' pytest-cov pytest-sugar
+	pip install 'black==21.12b0' 'pytest>=5.0' pytest-cov pytest-sugar
 
 
 ## devhooks:  install development hooks

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ devhooks:
 clean:
 	rm -rf __pycache__/ microhapulator/__pycache__/ microhapulator/*/__pycache__ build/ dist/ *.egg-info/
 
-## style:     check code style against PEP8
+## style:     check code style vs Black
 style:
-	pycodestyle --max-line-length=99 microhapulator/*.py microhapulator/*/*.py
+	black --line-length=99 --check microhapulator/*.py microhapulator/*/*.py setup.py
+
+## format:     autoformat Python code
+format:
+	black --line-length=99 microhapulator/*.py microhapulator/*/*.py setup.py

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # MicroHapulator
 
-Daniel Standage, 2018-2019  
+Daniel Standage, 2018-2021  
 https://github.com/bioforensics/microhapulator
 
 **MicroHapulator** is a package for analyzing and interpreting microhaplotype sequence data for forensic analysis.
@@ -30,7 +30,7 @@ conda install -c bioconda microhapulator
 
 Click the badge below to launch a quick interactive demo of MicroHapulator.
 
-- [![Binder][binderbadge]](https://mybinder.org/v2/gh/bioforensics/MicroHapulator/master?filepath=binder%2Fdemo-cli.ipynb) MicroHapulator CLI (`mhpl8r --help`) 
+- [![Binder][binderbadge]](https://mybinder.org/v2/gh/bioforensics/MicroHapulator/master?filepath=binder%2Fdemo-cli.ipynb) MicroHapulator CLI (`mhpl8r --help`)
 - [![Binder][binderbadge]](https://mybinder.org/v2/gh/bioforensics/MicroHapulator/master?filepath=binder%2Fdemo-api.ipynb) MicroHapulator Python API (`import microhapulator`)
 - [![Binder][binderbadge]](https://mybinder.org/v2/gh/bioforensics/MicroHapulator/master?filepath=binder%2Fdemo-sim.ipynb) Mock data simulation
 

--- a/microhapulator/__init__.py
+++ b/microhapulator/__init__.py
@@ -35,7 +35,8 @@ from microhapulator import cli
 
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions
 
 
@@ -44,21 +45,21 @@ teelog = False
 
 
 def package_file(path):
-    return resource_filename('microhapulator', path)
+    return resource_filename("microhapulator", path)
 
 
 @contextmanager
 def open(filename, mode):
-    if mode not in ('r', 'w'):
+    if mode not in ("r", "w"):
         raise ValueError('invalid mode "{}"'.format(mode))
-    if filename in ['-', None]:
-        filehandle = sys.stdin if mode == 'r' else sys.stdout
+    if filename in ["-", None]:
+        filehandle = sys.stdin if mode == "r" else sys.stdout
         yield filehandle
     else:
         openfunc = builtins.open
-        if filename.endswith('.gz'):
+        if filename.endswith(".gz"):
             openfunc = gzopen
-            mode += 't'
+            mode += "t"
         with openfunc(filename, mode) as filehandle:
             yield filehandle
 

--- a/microhapulator/__main__.py
+++ b/microhapulator/__main__.py
@@ -20,10 +20,10 @@ def main(arglist=None):  # pragma: no cover
     """
     args = microhapulator.cli.parse_args(arglist)
     if args.subcmd is None:
-        microhapulator.cli.get_parser().parse_args(['-h'])
+        microhapulator.cli.get_parser().parse_args(["-h"])
 
     assert args.subcmd in microhapulator.cli.mains
     mainmethod = microhapulator.cli.mains[args.subcmd]
-    versionmessage = '[MicroHapulator] running version {}'.format(microhapulator.__version__)
+    versionmessage = "[MicroHapulator] running version {}".format(microhapulator.__version__)
     microhapulator.plog(versionmessage)
     mainmethod(args)

--- a/microhapulator/_version.py
+++ b/microhapulator/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +276,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +294,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix)
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +307,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +342,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +456,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +482,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +502,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +511,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +534,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/microhapulator/balance.py
+++ b/microhapulator/balance.py
@@ -20,14 +20,14 @@ def count_and_sort(profile, include_discarded=True):
     for marker, mdata in profile.data["markers"].items():
         readcount = 0
         if include_discarded:
-            readcount += mdata['num_discarded_reads']
-        for haplotype, count in mdata['allele_counts'].items():
+            readcount += mdata["num_discarded_reads"]
+        for haplotype, count in mdata["allele_counts"].items():
             readcount += count
-        counts['Marker'].append(marker)
-        counts['ReadCount'].append(readcount)
-    data = pandas.DataFrame(counts)\
-        .sort_values(['ReadCount'], ascending=False)\
-        .reset_index(drop=True)
+        counts["Marker"].append(marker)
+        counts["ReadCount"].append(readcount)
+    data = (
+        pandas.DataFrame(counts).sort_values(["ReadCount"], ascending=False).reset_index(drop=True)
+    )
     return data
 
 
@@ -36,7 +36,7 @@ def balance(profile, include_discarded=True):
     with TemporaryDirectory() as tempdir:
         tfile = os.path.join(tempdir, "data.tsv")
         data.to_csv(tfile, index=False, header=False)
-        subprocess.run(['termgraph', tfile])
+        subprocess.run(["termgraph", tfile])
     return data
 
 

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -24,37 +24,37 @@ from . import type
 from . import unite
 
 mains = {
-    'balance': microhapulator.balance.main,
-    'contain': microhapulator.contain.main,
-    'contrib': microhapulator.contrib.main,
-    'diff': microhapulator.diff.main,
-    'dist': microhapulator.dist.main,
-    'mix': microhapulator.mix.main,
-    'prob': microhapulator.prob.main,
-    'seq': microhapulator.seq.main,
-    'sim': microhapulator.sim.main,
-    'type': microhapulator.type.main,
-    'unite': microhapulator.unite.main,
+    "balance": microhapulator.balance.main,
+    "contain": microhapulator.contain.main,
+    "contrib": microhapulator.contrib.main,
+    "diff": microhapulator.diff.main,
+    "dist": microhapulator.dist.main,
+    "mix": microhapulator.mix.main,
+    "prob": microhapulator.prob.main,
+    "seq": microhapulator.seq.main,
+    "sim": microhapulator.sim.main,
+    "type": microhapulator.type.main,
+    "unite": microhapulator.unite.main,
 }
 
 subparser_funcs = {
-    'balance': balance.subparser,
-    'contain': contain.subparser,
-    'contrib': contrib.subparser,
-    'diff': diff.subparser,
-    'dist': dist.subparser,
-    'mix': mix.subparser,
-    'prob': prob.subparser,
-    'seq': seq.subparser,
-    'sim': sim.subparser,
-    'type': type.subparser,
-    'unite': unite.subparser,
+    "balance": balance.subparser,
+    "contain": contain.subparser,
+    "contrib": contrib.subparser,
+    "diff": diff.subparser,
+    "dist": dist.subparser,
+    "mix": mix.subparser,
+    "prob": prob.subparser,
+    "seq": seq.subparser,
+    "sim": sim.subparser,
+    "type": type.subparser,
+    "unite": unite.subparser,
 }
 
 
 def get_parser():
     # https://patorjk.com/software/taag/, "Small" font
-    bubbletext = r'''
+    bubbletext = r"""
 ≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠
   __  __ _            _  _                _      _
  |  \/  (_)__ _ _ ___| || |__ _ _ __ _  _| |__ _| |_ ___ _ _
@@ -64,36 +64,46 @@ def get_parser():
 ≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠
 Invoke `mhpl8r <subcmd> --help` and replace `<subcmd>` with one of the
 subcommands listed below to see instructions for that operation.
-'''
-    subcommandstr = ', '.join(sorted(list(mains.keys())))
+"""
+    subcommandstr = ", ".join(sorted(list(mains.keys())))
     parser = ArgumentParser(
         description=bubbletext,
         formatter_class=RawDescriptionHelpFormatter,
     )
-    parser._positionals.title = 'Subcommands'
-    parser._optionals.title = 'Global arguments'
-    parser.add_argument('-v', '--version', action='version',
-                        version='MicroHapulator v{}'.format(microhapulator.__version__))
-    parser.add_argument('-l', '--logfile', metavar='F', help='log file for '
-                        'diagnostic messages, warnings, and errors')
-    parser.add_argument('--tee', action='store_true', help='write diagnostic '
-                        'output to logfile AND terminal (stderr)')
-    subparsers = parser.add_subparsers(dest='subcmd', metavar='subcmd',
-                                       help=subcommandstr)
+    parser._positionals.title = "Subcommands"
+    parser._optionals.title = "Global arguments"
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version="MicroHapulator v{}".format(microhapulator.__version__),
+    )
+    parser.add_argument(
+        "-l",
+        "--logfile",
+        metavar="F",
+        help="log file for " "diagnostic messages, warnings, and errors",
+    )
+    parser.add_argument(
+        "--tee",
+        action="store_true",
+        help="write diagnostic " "output to logfile AND terminal (stderr)",
+    )
+    subparsers = parser.add_subparsers(dest="subcmd", metavar="subcmd", help=subcommandstr)
     for func in subparser_funcs.values():
         func(subparsers)
     return parser
 
 
 def parse_args(arglist=None):  # pragma: no cover
-    '''Parse arguments from the command line and configure logging.
+    """Parse arguments from the command line and configure logging.
 
     Calling this function in a testing context has proven problematic. Please
     use only in a runtime context.
-    '''
+    """
     args = get_parser().parse_args(arglist)
     microhapulator.logstream = sys.stderr
-    if args.logfile and args.logfile != '-':
-        microhapulator.logstream = open(args.logfile, 'w')
+    if args.logfile and args.logfile != "-":
+        microhapulator.logstream = open(args.logfile, "w")
     microhapulator.teelog = args.tee
     return args

--- a/microhapulator/cli/balance.py
+++ b/microhapulator/cli/balance.py
@@ -9,12 +9,15 @@ import sys
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('balance')
-    cli.add_argument('-c', '--csv', metavar='FILE', help='write read counts to FILE in CSV format')
+    cli = subparsers.add_parser("balance")
+    cli.add_argument("-c", "--csv", metavar="FILE", help="write read counts to FILE in CSV format")
     cli.add_argument(
-        '-D', '--no-discarded', dest='discarded', action='store_false',
-        help='do not included mapping but discarded reads in read counts; by default, reads that '
-        'are mapped to the marker but discarded because they do not span all variants at the '
-        'marker are included'
+        "-D",
+        "--no-discarded",
+        dest="discarded",
+        action="store_false",
+        help="do not included mapping but discarded reads in read counts; by default, reads that "
+        "are mapped to the marker but discarded because they do not span all variants at the "
+        "marker are included",
     )
-    cli.add_argument('input', help='typing result in JSON format')
+    cli.add_argument("input", help="typing result in JSON format")

--- a/microhapulator/cli/contain.py
+++ b/microhapulator/cli/contain.py
@@ -9,14 +9,13 @@
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('contain')
+    cli = subparsers.add_parser("contain")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
-    cli.add_argument(
-        'profile1', help='simulated or inferred genotype profile in JSON format'
-    )
-    cli.add_argument(
-        'profile2', help='simulated or inferred genotype profile in JSON format'
-    )
+    cli.add_argument("profile1", help="simulated or inferred genotype profile in JSON format")
+    cli.add_argument("profile2", help="simulated or inferred genotype profile in JSON format")

--- a/microhapulator/cli/contrib.py
+++ b/microhapulator/cli/contrib.py
@@ -9,29 +9,41 @@
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('contrib')
+    cli = subparsers.add_parser("contrib")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
     cli.add_argument(
-        '-j', '--json', metavar='FILE', help='precomputed genotype profile in '
-        'JSON format; if not specified, must supply arguments for '
-        '`--refr-fasta` and `--bam` flags'
+        "-j",
+        "--json",
+        metavar="FILE",
+        help="precomputed genotype profile in "
+        "JSON format; if not specified, must supply arguments for "
+        "`--refr-fasta` and `--bam` flags",
     )
     cli.add_argument(
-        '-r', '--refr', metavar='FILE', help='microhap marker sequences in '
-        'Fasta format'
+        "-r", "--refr", metavar="FILE", help="microhap marker sequences in " "Fasta format"
     )
     cli.add_argument(
-        '-b', '--bam', metavar='FILE', help='aligned and sorted reads in BAM '
-        'format'
+        "-b", "--bam", metavar="FILE", help="aligned and sorted reads in BAM " "format"
     )
     cli.add_argument(
-        '-s', '--static', metavar='ST', type=int, default=None,
-        help='apply a static threshold for calling genotypes; see `mhpl8r type --help`'
+        "-s",
+        "--static",
+        metavar="ST",
+        type=int,
+        default=None,
+        help="apply a static threshold for calling genotypes; see `mhpl8r type --help`",
     )
     cli.add_argument(
-        '-d', '--dynamic', metavar='DT', type=float, default=None,
-        help='apply a dynamic threshold for calling genotypes; see `mhpl8r type --help`'
+        "-d",
+        "--dynamic",
+        metavar="DT",
+        type=float,
+        default=None,
+        help="apply a dynamic threshold for calling genotypes; see `mhpl8r type --help`",
     )

--- a/microhapulator/cli/diff.py
+++ b/microhapulator/cli/diff.py
@@ -9,14 +9,13 @@
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('diff')
+    cli = subparsers.add_parser("diff")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
-    cli.add_argument(
-        'profile1', help='simulated or inferred genotype profile in JSON format'
-    )
-    cli.add_argument(
-        'profile2', help='simulated or inferred genotype profile in JSON format'
-    )
+    cli.add_argument("profile1", help="simulated or inferred genotype profile in JSON format")
+    cli.add_argument("profile2", help="simulated or inferred genotype profile in JSON format")

--- a/microhapulator/cli/dist.py
+++ b/microhapulator/cli/dist.py
@@ -9,14 +9,13 @@
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('dist')
+    cli = subparsers.add_parser("dist")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
-    cli.add_argument(
-        'profile1', help='simulated or inferred profile in JSON format'
-    )
-    cli.add_argument(
-        'profile2', help='simulated or inferred profile in JSON format'
-    )
+    cli.add_argument("profile1", help="simulated or inferred profile in JSON format")
+    cli.add_argument("profile2", help="simulated or inferred profile in JSON format")

--- a/microhapulator/cli/mix.py
+++ b/microhapulator/cli/mix.py
@@ -9,11 +9,12 @@
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('mix')
+    cli = subparsers.add_parser("mix")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
-    cli.add_argument(
-        'profiles', nargs='+', help='simulated genotype profiles in JSON format'
-    )
+    cli.add_argument("profiles", nargs="+", help="simulated genotype profiles in JSON format")

--- a/microhapulator/cli/prob.py
+++ b/microhapulator/cli/prob.py
@@ -10,31 +10,32 @@
 
 def subparser(subparsers):
     desc = (
-        'If a single profile is provided, the random match probability of '
-        'the profile is computed. If a pair of profiles is provided, a '
-        'likelihood ratio test is performed comparing the likelihood that the '
-        'two profiles are from the same individual versus the likelihood '
-        'that the two profiles are from random unrelated individuals. The '
-        'genotype profiles are assumed to be identical, and differences '
-        'between the two profiles are assumed to be the result of genotyping '
-        'error. The test does not make sense for profiles with many allele '
-        'differences.'
+        "If a single profile is provided, the random match probability of "
+        "the profile is computed. If a pair of profiles is provided, a "
+        "likelihood ratio test is performed comparing the likelihood that the "
+        "two profiles are from the same individual versus the likelihood "
+        "that the two profiles are from random unrelated individuals. The "
+        "genotype profiles are assumed to be identical, and differences "
+        "between the two profiles are assumed to be the result of genotyping "
+        "error. The test does not make sense for profiles with many allele "
+        "differences."
     )
-    cli = subparsers.add_parser('prob', description=desc)
+    cli = subparsers.add_parser("prob", description=desc)
     cli.add_argument(
-        '-e', '--erate', type=float, metavar='ε', default=0.001, help='rate '
-        'at which errors in genotyping are expected; default is 0.001'
-    )
-    cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
-    )
-    cli.add_argument(
-        'population', help='indicate which allele frequencies to use'
+        "-e",
+        "--erate",
+        type=float,
+        metavar="ε",
+        default=0.001,
+        help="rate " "at which errors in genotyping are expected; default is 0.001",
     )
     cli.add_argument(
-        'profile1', help='profile in JSON format'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
-    cli.add_argument(
-        'profile2', nargs='?', default=None, help='profile in JSON format'
-    )
+    cli.add_argument("population", help="indicate which allele frequencies to use")
+    cli.add_argument("profile1", help="profile in JSON format")
+    cli.add_argument("profile2", nargs="?", default=None, help="profile in JSON format")

--- a/microhapulator/cli/seq.py
+++ b/microhapulator/cli/seq.py
@@ -18,39 +18,55 @@ class OutfilesAction(Action):
         if numargs < 1 or numargs > 2:
             message = f'expected 1 or 2 output filenames, got {numargs}: {",".join(values)}'
             parser.error(message)
-        filehandles = [open(filename, 'w') for filename in values]
+        filehandles = [open(filename, "w") for filename in values]
         setattr(namespace, self.dest, filehandles)
 
 
 def subparser(subparsers):
     desc = (
-        'Given one or more diploid genotype profiles, simulate Illumina MiSeq '
+        "Given one or more diploid genotype profiles, simulate Illumina MiSeq "
         'sequencing of the given "sample."'
     )
-    cli = subparsers.add_parser('seq', description=desc)
+    cli = subparsers.add_parser("seq", description=desc)
     cli.add_argument(
-        '-o', '--out', nargs='+', default=[sys.stdout], action=OutfilesAction,
-        help='write simulated paired-end MiSeq reads in FASTQ format to the specified file(s); if '
-        'one filename is provided, reads are interleaved and written to the file; if two '
-        'filenames are provided, reads are written to paired files; by default, reads are '
-        'interleaved and written to the terminal (standard output)'
+        "-o",
+        "--out",
+        nargs="+",
+        default=[sys.stdout],
+        action=OutfilesAction,
+        help="write simulated paired-end MiSeq reads in FASTQ format to the specified file(s); if "
+        "one filename is provided, reads are interleaved and written to the file; if two "
+        "filenames are provided, reads are written to paired files; by default, reads are "
+        "interleaved and written to the terminal (standard output)",
     )
     cli.add_argument(
-        '-n', '--num-reads', type=int, default=500000, metavar='N',
-        help='number of reads to simulate; default is 500000'
+        "-n",
+        "--num-reads",
+        type=int,
+        default=500000,
+        metavar="N",
+        help="number of reads to simulate; default is 500000",
     )
     cli.add_argument(
-        '-p', '--proportions', type=float, nargs='+', metavar='P',
-        help='simulated mixture samples with multiple contributors at the '
-        'specified proportions; by default even proportions are used'
+        "-p",
+        "--proportions",
+        type=float,
+        nargs="+",
+        metavar="P",
+        help="simulated mixture samples with multiple contributors at the "
+        "specified proportions; by default even proportions are used",
     )
     cli.add_argument(
-        '-s', '--seeds', nargs='+', type=int, default=None, metavar='INT',
-        help='seeds for random number generator, 1 per profile'
+        "-s",
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="seeds for random number generator, 1 per profile",
     )
-    cli.add_argument('--signature', default=None, help=SUPPRESS)
-    cli.add_argument('--threads', type=int, default=1, metavar='INT', help=SUPPRESS)
+    cli.add_argument("--signature", default=None, help=SUPPRESS)
+    cli.add_argument("--threads", type=int, default=1, metavar="INT", help=SUPPRESS)
     cli.add_argument(
-        'profiles', nargs='+', help='one or more simple or complex profiles '
-        '(JSON files)'
+        "profiles", nargs="+", help="one or more simple or complex profiles " "(JSON files)"
     )

--- a/microhapulator/cli/sim.py
+++ b/microhapulator/cli/sim.py
@@ -10,35 +10,46 @@
 
 def subparser(subparsers):
     desc = (
-        'Use precomputed population allele frequencies to simulate a diploid '
-        'DNA profile for the specified panel of microhaplotypes.'
+        "Use precomputed population allele frequencies to simulate a diploid "
+        "DNA profile for the specified panel of microhaplotypes."
     )
-    cli = subparsers.add_parser('sim', description=desc)
+    cli = subparsers.add_parser("sim", description=desc)
 
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write simulated profile data in '
-        'JSON format to FILE'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help="write simulated profile data in " "JSON format to FILE",
     )
     cli.add_argument(
-        '--haplo-seq', metavar='FILE', help='write simulated haplotype '
-        'sequences in FASTA format to FILE'
+        "--haplo-seq",
+        metavar="FILE",
+        help="write simulated haplotype " "sequences in FASTA format to FILE",
     )
     cli.add_argument(
-        '-s', '--seed', type=int, default=None, metavar='INT', help='seed for '
-        'random number generator'
+        "-s",
+        "--seed",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="seed for " "random number generator",
     )
     cli.add_argument(
-        '-r', '--relaxed', action='store_true', help='if a marker in the panel '
-        'has no frequency data for a requested population, randomly draw an '
-        'allele (from a uniform distribution) from all possible alleles; by '
-        'default, these markers are exluded from simulation'
+        "-r",
+        "--relaxed",
+        action="store_true",
+        help="if a marker in the panel "
+        "has no frequency data for a requested population, randomly draw an "
+        "allele (from a uniform distribution) from all possible alleles; by "
+        "default, these markers are exluded from simulation",
     )
     cli.add_argument(
-        'popid', nargs=2, help='population identifiers for the two parental '
-        'haplotypes'
+        "popid", nargs=2, help="population identifiers for the two parental " "haplotypes"
     )
     cli.add_argument(
-        'panel', nargs='+', help='panel from which to simulate microhap '
-        'profiles; can be a list of MicroHapDB marker identifiers or a '
-        'filename containing marker identifiers (one per line)'
+        "panel",
+        nargs="+",
+        help="panel from which to simulate microhap "
+        "profiles; can be a list of MicroHapDB marker identifiers or a "
+        "filename containing marker identifiers (one per line)",
     )

--- a/microhapulator/cli/type.py
+++ b/microhapulator/cli/type.py
@@ -12,38 +12,58 @@ import sys
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('type')
+    cli = subparsers.add_parser("type")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', default=sys.stdout, help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        default=sys.stdout,
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
     cli.add_argument(
-        '-b', '--base-qual', metavar='B', type=int, default=10,
-        help='minimum base quality required for haplotype calling; by default B=10, '
-        'corresponding to Q10, i.e., 90%% probability that base call is correct'
+        "-b",
+        "--base-qual",
+        metavar="B",
+        type=int,
+        default=10,
+        help="minimum base quality required for haplotype calling; by default B=10, "
+        "corresponding to Q10, i.e., 90%% probability that base call is correct",
     )
     cli.add_argument(
-        '-e', '--effcov', metavar='EC', type=float, default=0.25,
-        help='only reads that span all SNPs in a microhaplotype are retained, all others are '
-        'discarded; if most of the reads related to a marker are discarded, it has low *effective '
-        'coverage*; this parameter sets that threshold, i.e., if the fraction of retained reads '
-        'is < EC it is considered low effective coverage; by default EC=0.25 (or 25%%)'
+        "-e",
+        "--effcov",
+        metavar="EC",
+        type=float,
+        default=0.25,
+        help="only reads that span all SNPs in a microhaplotype are retained, all others are "
+        "discarded; if most of the reads related to a marker are discarded, it has low *effective "
+        "coverage*; this parameter sets that threshold, i.e., if the fraction of retained reads "
+        "is < EC it is considered low effective coverage; by default EC=0.25 (or 25%%)",
     )
     cli.add_argument(
-        '-s', '--static', metavar='ST', type=int, default=None,
-        help='apply a static threshold for calling genotypes, i.e., discard any haplotype whose '
-        'count is less than ST; by default, ST is undefined, the static filter is not applied, '
-        'and only raw haplotype counts are reported, not genotype calls; if --dynamic is also '
-        'defined, --static is only applied to markers with low effective coverage'
+        "-s",
+        "--static",
+        metavar="ST",
+        type=int,
+        default=None,
+        help="apply a static threshold for calling genotypes, i.e., discard any haplotype whose "
+        "count is less than ST; by default, ST is undefined, the static filter is not applied, "
+        "and only raw haplotype counts are reported, not genotype calls; if --dynamic is also "
+        "defined, --static is only applied to markers with low effective coverage",
     )
     cli.add_argument(
-        '-d', '--dynamic', metavar='DT', type=float, default=None,
-        help='apply a dynamic threshold for calling genotypes, i.e., if AC is the average count '
-        'of all haplotypes observed at the marker, discard any haplotypes whose count is less '
-        'than DT * AC; by default, DT is undefined, the dynamic filter is not applied, and only '
-        'raw haplotype counts are reported, not genotype calls; if --static is also defined, '
-        '--dynamic is only applied to markers with high effective coverage'
+        "-d",
+        "--dynamic",
+        metavar="DT",
+        type=float,
+        default=None,
+        help="apply a dynamic threshold for calling genotypes, i.e., if AC is the average count "
+        "of all haplotypes observed at the marker, discard any haplotypes whose count is less "
+        "than DT * AC; by default, DT is undefined, the dynamic filter is not applied, and only "
+        "raw haplotype counts are reported, not genotype calls; if --static is also defined, "
+        "--dynamic is only applied to markers with high effective coverage",
     )
-    cli.add_argument('-m', '--max-depth', metavar='M', type=float, default=1e6, help=SUPPRESS)
-    cli.add_argument('refr', help='microhap marker sequences in Fasta format')
-    cli.add_argument('bam', help='aligned and sorted reads in BAM format')
+    cli.add_argument("-m", "--max-depth", metavar="M", type=float, default=1e6, help=SUPPRESS)
+    cli.add_argument("refr", help="microhap marker sequences in Fasta format")
+    cli.add_argument("bam", help="aligned and sorted reads in BAM format")

--- a/microhapulator/cli/unite.py
+++ b/microhapulator/cli/unite.py
@@ -9,18 +9,21 @@
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser('unite')
+    cli = subparsers.add_parser("unite")
     cli.add_argument(
-        '-o', '--out', metavar='FILE', help='write output to "FILE"; by '
-        'default, output is written to the terminal (standard output)'
+        "-o",
+        "--out",
+        metavar="FILE",
+        help='write output to "FILE"; by '
+        "default, output is written to the terminal (standard output)",
     )
     cli.add_argument(
-        '-s', '--seed', type=int, default=None, metavar='INT', help='seed for '
-        'random number generator'
+        "-s",
+        "--seed",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="seed for " "random number generator",
     )
-    cli.add_argument(
-        'mom', help='simulated or inferred genotype in JSON format'
-    )
-    cli.add_argument(
-        'dad', help='simulated or inferred genotype in JSON format'
-    )
+    cli.add_argument("mom", help="simulated or inferred genotype in JSON format")
+    cli.add_argument("dad", help="simulated or inferred genotype in JSON format")

--- a/microhapulator/contain.py
+++ b/microhapulator/contain.py
@@ -13,7 +13,7 @@ from microhapulator.profile import Profile
 
 
 def contain(p1, p2):
-    '''Compute the proportion of alleles from p2 present in p1.'''
+    """Compute the proportion of alleles from p2 present in p1."""
     total = 0
     contained = 0
     for marker in p2.markers():
@@ -25,14 +25,11 @@ def contain(p1, p2):
 
 
 def main(args):
-    contained, total = contain(
-        Profile(fromfile=args.profile1),
-        Profile(fromfile=args.profile2)
-    )
+    contained, total = contain(Profile(fromfile=args.profile1), Profile(fromfile=args.profile2))
     data = {
-        'containment': round(contained / total, 4),
-        'contained_alleles': contained,
-        'total_alleles': total
+        "containment": round(contained / total, 4),
+        "contained_alleles": contained,
+        "total_alleles": total,
     }
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         json.dump(data, fh, indent=4)

--- a/microhapulator/contrib.py
+++ b/microhapulator/contrib.py
@@ -16,7 +16,7 @@ import sys
 
 def load_profile(bamfile=None, refrfasta=None, json=None, **kwargs):
     if not json and (not bamfile or not refrfasta):
-        message = 'must provide either JSON profile or BAM and refr FASTA'
+        message = "must provide either JSON profile or BAM and refr FASTA"
         raise ValueError(message)
     if json:
         profile = microhapulator.profile.Profile(fromfile=json)
@@ -36,14 +36,17 @@ def contrib(profile):
 
 def main(args):
     profile = load_profile(
-        bamfile=args.bam, refrfasta=args.refr, json=args.json, static=args.static,
-        dynamic=args.dynamic
+        bamfile=args.bam,
+        refrfasta=args.refr,
+        json=args.json,
+        static=args.static,
+        dynamic=args.dynamic,
     )
     ncontrib, nloci, ploci = contrib(profile)
     data = {
-        'min_num_contrib': ncontrib,
-        'num_loci_max_alleles': nloci,
-        'perc_loci_max_alleles': ploci,
+        "min_num_contrib": ncontrib,
+        "num_loci_max_alleles": nloci,
+        "perc_loci_max_alleles": ploci,
     }
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         json.dump(data, fh, indent=4)

--- a/microhapulator/diff.py
+++ b/microhapulator/diff.py
@@ -25,12 +25,12 @@ def diff(prof1, prof2):
 
 def main(args):
     differ = diff(Profile(fromfile=args.profile1), Profile(fromfile=args.profile2))
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         for marker, diff1, diff2 in differ:
             print(marker, file=fh)
             if len(diff1) > 0:
                 for haplotype in sorted(diff1):
-                    print('>>>', haplotype, file=fh)
+                    print(">>>", haplotype, file=fh)
             if len(diff2) > 0:
                 for haplotype in sorted(diff2):
-                    print('<<<', haplotype, file=fh)
+                    print("<<<", haplotype, file=fh)

--- a/microhapulator/dist.py
+++ b/microhapulator/dist.py
@@ -25,7 +25,7 @@ def dist(p1, p2):
 def main(args):
     d = dist(Profile(fromfile=args.profile1), Profile(fromfile=args.profile2))
     data = {
-        'hamming_distance': d,
+        "hamming_distance": d,
     }
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         json.dump(data, fh, indent=4)

--- a/microhapulator/mix.py
+++ b/microhapulator/mix.py
@@ -14,5 +14,5 @@ from microhapulator.profile import SimulatedProfile
 def main(args):
     profiles = [SimulatedProfile(pfile) for pfile in args.profiles]
     combined = SimulatedProfile.merge(profiles)
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         combined.dump(fh)

--- a/microhapulator/panel.py
+++ b/microhapulator/panel.py
@@ -17,8 +17,8 @@ import pandas
 def validate_markers(panel):
     valid_markers = microhapdb.marker.standardize_ids(panel)
     if len(valid_markers) < len(panel):
-        message = 'panel includes duplicate and/or invalid marker IDs'
-        microhapulator.plog('[MicroHapulator::panel] WARNING', message)
+        message = "panel includes duplicate and/or invalid marker IDs"
+        microhapulator.plog("[MicroHapulator::panel] WARNING", message)
     return valid_markers
 
 
@@ -28,11 +28,11 @@ def sample_panel(popids, markers):
             f = microhapdb.frequencies
             allelefreqs = f[(f.Population == popid) & (f.Marker == markerid)]
             if len(allelefreqs) == 0:
-                message = 'no allele frequencies available'
+                message = "no allele frequencies available"
                 message += ' for population "{pop}"'.format(pop=popid)
                 message += ' at marker "{loc}"'.format(loc=markerid)
                 message += '; in "relaxed" mode, drawing an allele uniformly'
-                microhapulator.plog('[MicroHapulator::panel] WARNING:', message)
+                microhapulator.plog("[MicroHapulator::panel] WARNING:", message)
                 alleles = list(f[f.Marker == markerid].Allele.unique())
                 sampled_allele = choice(alleles)
             else:
@@ -45,12 +45,12 @@ def sample_panel(popids, markers):
 
 def validate_populations(popids):
     if len(popids) not in (1, 2):
-        message = 'please provide only 1 or 2 population IDs'
+        message = "please provide only 1 or 2 population IDs"
         raise ValueError(message)
     popids = sorted(set(popids))
     haplopops = list(microhapdb.population.standardize_ids(popids))
     if len(haplopops) < len(popids):
-        raise ValueError('invalid or duplicated population ID(s)')
+        raise ValueError("invalid or duplicated population ID(s)")
     if len(haplopops) == 1:
         haplopops = haplopops * 2
     return haplopops
@@ -65,10 +65,10 @@ def check_markers_for_population(markers, popid, suppress=False):
     idsfound = list(allelefreqs.Marker.unique())
     nodata = set(markers) - set(idsfound)
     if len(nodata) > 0 and not suppress:
-        message = 'no allele frequency data available'
+        message = "no allele frequency data available"
         message += ' for population "{pop:s}"'.format(pop=popid)
-        message += ' at the following microhap markers: {loc:s}'.format(loc=','.join(nodata))
-        microhapulator.plog('[MicroHapulator::panel] WARNING:', message)
+        message += " at the following microhap markers: {loc:s}".format(loc=",".join(nodata))
+        microhapulator.plog("[MicroHapulator::panel] WARNING:", message)
     return sorted(set(markers) & set(idsfound))
 
 

--- a/microhapulator/prob.py
+++ b/microhapulator/prob.py
@@ -29,9 +29,9 @@ def main(args):
         raise ValueError(message)
     popid = popids.iloc[0]
     result = prob(popid, prof1, prof2=prof2, erate=args.erate)
-    key = 'random_match_probability' if prof2 is None else 'likelihood_ratio'
+    key = "random_match_probability" if prof2 is None else "likelihood_ratio"
     data = {
-        key: '{:.3E}'.format(result),
+        key: "{:.3E}".format(result),
     }
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         json.dump(data, fh, indent=4)

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -19,7 +19,7 @@ from numpy.random import choice
 
 
 def load_schema():
-    with microhapulator.open(microhapulator.package_file('profile-schema.json'), 'r') as fh:
+    with microhapulator.open(microhapulator.package_file("profile-schema.json"), "r") as fh:
         return json.load(fh)
 
 
@@ -33,12 +33,12 @@ class Profile(object):
         allmarkers = mom.markers() | dad.markers()
         commonmarkers = mom.markers() & dad.markers()
         if len(commonmarkers) == 0:
-            raise ValueError('mom and dad profiles have no markers in common')
+            raise ValueError("mom and dad profiles have no markers in common")
         notshared = allmarkers - commonmarkers
         if len(notshared) > 0:
-            message = 'markers not common to mom and dad profiles are excluded: '
-            message += ', '.join(notshared)
-            microhapulator.plog('[MicroHapulator::profile]', message)
+            message = "markers not common to mom and dad profiles are excluded: "
+            message += ", ".join(notshared)
+            microhapulator.plog("[MicroHapulator::profile]", message)
         for parent, hapid in zip((mom, dad), (0, 1)):
             for marker in sorted(commonmarkers):
                 haploallele = choice(sorted(parent.alleles(marker)))
@@ -49,7 +49,7 @@ class Profile(object):
         global schema
         if fromfile:
             if isinstance(fromfile, str):
-                with microhapulator.open(fromfile, 'r') as fh:
+                with microhapulator.open(fromfile, "r") as fh:
                     self.data = json.load(fh)
             else:
                 self.data = json.load(fromfile)
@@ -61,42 +61,45 @@ class Profile(object):
 
     @property
     def gttype(self):
-        return 'base'
+        return "base"
 
     @property
     def ploidy(self):
-        return self.data['ploidy']
+        return self.data["ploidy"]
 
     def initialize(self):
         data = {
-            'version': microhapulator.__version__,
-            'type': self.gttype,
-            'ploidy': None,
-            'markers': dict(),
+            "version": microhapulator.__version__,
+            "type": self.gttype,
+            "ploidy": None,
+            "markers": dict(),
         }
         return data
 
     def haplotypes(self):
         hapids = set()
-        for markerid, markerdata in self.data['markers'].items():
-            for alleledata in markerdata['genotype']:
-                if 'haplotype' in alleledata:
-                    hapids.add(alleledata['haplotype'])
+        for markerid, markerdata in self.data["markers"].items():
+            for alleledata in markerdata["genotype"]:
+                if "haplotype" in alleledata:
+                    hapids.add(alleledata["haplotype"])
         assert sorted(hapids) == sorted(range(len(hapids)))
         return hapids
 
     def markers(self):
-        return set(list(self.data['markers']))
+        return set(list(self.data["markers"]))
 
     def alleles(self, markerid, haplotype=None):
-        if markerid not in self.data['markers']:
+        if markerid not in self.data["markers"]:
             return set()
         if haplotype is not None:
             return set(
-                [a['allele'] for a in self.data['markers'][markerid]['genotype']
-                 if 'haplotype' in a and a['haplotype'] == haplotype]
+                [
+                    a["allele"]
+                    for a in self.data["markers"][markerid]["genotype"]
+                    if "haplotype" in a and a["haplotype"] == haplotype
+                ]
             )
-        return set([a['allele'] for a in self.data['markers'][markerid]['genotype']])
+        return set([a["allele"] for a in self.data["markers"][markerid]["genotype"]])
 
     def rand_match_prob(self, popid):
         """Compute the random match probability of this profile.
@@ -110,14 +113,14 @@ class Profile(object):
             alleles = self.alleles(marker)
             diploid_consistent = 1 <= len(alleles) <= 2
             if not diploid_consistent:
-                message = 'cannot compute random match prob. for marker with {:d} alleles'.format(
+                message = "cannot compute random match prob. for marker with {:d} alleles".format(
                     len(alleles)
                 )
                 raise RandomMatchError(message)
             result = microhapdb.frequencies[
-                (microhapdb.frequencies.Population == popid) &
-                (microhapdb.frequencies.Marker == marker) &
-                (microhapdb.frequencies.Allele.isin(alleles))
+                (microhapdb.frequencies.Population == popid)
+                & (microhapdb.frequencies.Marker == marker)
+                & (microhapdb.frequencies.Allele.isin(alleles))
             ]
             if len(alleles) == 1:
                 p = 0.001
@@ -150,8 +153,8 @@ class Profile(object):
         The test only makes sense when the two profiles being compared are
         identical or nearly identical.
         """
-        assert self.data['ploidy'] in (2, None)
-        assert other.data['ploidy'] in (2, None)
+        assert self.data["ploidy"] in (2, None)
+        assert other.data["ploidy"] in (2, None)
         mismatches = 0
         for marker in self.markers():
             selfalleles = self.alleles(marker)
@@ -168,7 +171,7 @@ class Profile(object):
 
     def dump(self, outfile):
         if isinstance(outfile, str):
-            with microhapulator.open(outfile, 'w') as fh:
+            with microhapulator.open(outfile, "w") as fh:
                 json.dump(self.data, fh, indent=4, sort_keys=True)
         else:
             json.dump(self.data, outfile, indent=4, sort_keys=True)
@@ -195,16 +198,16 @@ class Profile(object):
                 raise ValueError('unknown marker identifier "{:s}"'.format(marker))
             markerdata = result.iloc[0]
             context = TargetAmplicon(markerdata, delta=30, minlen=350)
-            coords = list(map(int, markerdata.Offsets.split(',')))
+            coords = list(map(int, markerdata.Offsets.split(",")))
             coords = list(map(context.global_to_local, coords))
             variants = [list() for _ in range(len(coords))]
             for haplotype in sorted(hapids):
                 allele = self.alleles(marker, haplotype=haplotype).pop()
-                for var, varlist in zip(allele.split(','), variants):
+                for var, varlist in zip(allele.split(","), variants):
                     varlist.append(var)
             for coord, var in zip(coords, variants):
-                allelestr = '|'.join(var)
-                yield '\t'.join((marker, str(coord), str(coord + 1), allelestr))
+                allelestr = "|".join(var)
+                yield "\t".join((marker, str(coord), str(coord + 1), allelestr))
 
     @property
     def seqstream(self):
@@ -222,7 +225,7 @@ class Profile(object):
 
     @property
     def haploseqs(self):
-        '''Apply genotype to reference and construct full haplotype sequences.'''
+        """Apply genotype to reference and construct full haplotype sequences."""
         mutator = mutate(self.seqstream, self.bedstream)
         for defline, sequence in mutator:
             yield defline, sequence
@@ -263,24 +266,25 @@ class SimulatedProfile(Profile):
     mh21KK-316 179     180     G|G
     mh21KK-316 242     243     T|C
     """
+
     def populate_from_bed(bedfile):
-        with microhapulator.open(bedfile, 'r') as fh:
+        with microhapulator.open(bedfile, "r") as fh:
             line = next(fh)
-            ploidy = line.count('|') + 1
+            ploidy = line.count("|") + 1
             fh.seek(0)
             marker_alleles = defaultdict(lambda: [list() for _ in range(ploidy)])
             for line in fh:
                 line = line.strip()
-                if line == '':
+                if line == "":
                     continue
-                marker, start, end, allelestr = line.split('\t')
-                alleles = allelestr.split('|')
+                marker, start, end, allelestr = line.split("\t")
+                alleles = allelestr.split("|")
                 for i, a in enumerate(alleles):
                     marker_alleles[marker][i].append(a)
             profile = SimulatedProfile(ploidy=ploidy)
             for marker, allele_list in marker_alleles.items():
                 for i, allele in enumerate(allele_list):
-                    profile.add(i, marker, ','.join(allele))
+                    profile.add(i, marker, ",".join(allele))
             return profile
 
     def merge(profiles):
@@ -288,27 +292,27 @@ class SimulatedProfile(Profile):
         gt = SimulatedProfile(ploidy=ploidy)
         offset = 0
         for profile in profiles:
-            for markerid, markerdata in sorted(profile.data['markers'].items()):
-                for allele in markerdata['genotype']:
-                    gt.add(offset + allele['haplotype'], markerid, allele['allele'])
+            for markerid, markerdata in sorted(profile.data["markers"].items()):
+                for allele in markerdata["genotype"]:
+                    gt.add(offset + allele["haplotype"], markerid, allele["allele"])
             offset += 2
         return gt
 
     def __init__(self, fromfile=None, ploidy=0):
         super(SimulatedProfile, self).__init__(fromfile=fromfile)
         if ploidy:
-            self.data['ploidy'] = ploidy
+            self.data["ploidy"] = ploidy
 
     def add(self, hapid, marker, allele):
-        if self.data['ploidy'] is not None and self.data['ploidy'] > 0:
-            assert hapid in range(self.data['ploidy'])
-        if marker not in self.data['markers']:
-            self.data['markers'][marker] = {'genotype': list()}
-        self.data['markers'][marker]['genotype'].append({'allele': allele, 'haplotype': hapid})
+        if self.data["ploidy"] is not None and self.data["ploidy"] > 0:
+            assert hapid in range(self.data["ploidy"])
+        if marker not in self.data["markers"]:
+            self.data["markers"][marker] = {"genotype": list()}
+        self.data["markers"][marker]["genotype"].append({"allele": allele, "haplotype": hapid})
 
     @property
     def gttype(self):
-        return 'SimulatedProfile'
+        return "SimulatedProfile"
 
 
 class ObservedProfile(Profile):
@@ -316,32 +320,32 @@ class ObservedProfile(Profile):
         super(ObservedProfile, self).__init__(fromfile=fromfile)
 
     def record_coverage(self, marker, cov_by_pos, ndiscarded=0):
-        self.data['markers'][marker] = {
-            'mean_coverage': 0.0,
-            'min_coverage': 0,
-            'max_coverage': 0,
-            'num_discarded_reads': ndiscarded,
-            'allele_counts': dict(),
+        self.data["markers"][marker] = {
+            "mean_coverage": 0.0,
+            "min_coverage": 0,
+            "max_coverage": 0,
+            "num_discarded_reads": ndiscarded,
+            "allele_counts": dict(),
         }
         if len(cov_by_pos) > 0:
             avgcov = sum(cov_by_pos) / len(cov_by_pos)
-            self.data['markers'][marker]['mean_coverage'] = round(avgcov, 1)
-            self.data['markers'][marker]['min_coverage'] = min(cov_by_pos)
-            self.data['markers'][marker]['max_coverage'] = max(cov_by_pos)
+            self.data["markers"][marker]["mean_coverage"] = round(avgcov, 1)
+            self.data["markers"][marker]["min_coverage"] = min(cov_by_pos)
+            self.data["markers"][marker]["max_coverage"] = max(cov_by_pos)
 
     def record_allele(self, marker, allele, count):
-        self.data['markers'][marker]['allele_counts'][allele] = count
+        self.data["markers"][marker]["allele_counts"][allele] = count
 
     def infer(self, ecthreshold=0.25, static=None, dynamic=None):
-        for marker, mdata in self.data['markers'].items():
+        for marker, mdata in self.data["markers"].items():
             if static is None and dynamic is None:
                 # No thresholds for calling haplotypes, just report raw haplotype counts
-                self.data['markers'][marker]['genotype'] = list()
+                self.data["markers"][marker]["genotype"] = list()
                 continue
             gt = set()
-            allelecounts = mdata['allele_counts']
+            allelecounts = mdata["allele_counts"]
             for allele, count in allelecounts.items():
-                eff_cov = 1.0 - (mdata['num_discarded_reads'] / mdata['max_coverage'])
+                eff_cov = 1.0 - (mdata["num_discarded_reads"] / mdata["max_coverage"])
                 if dynamic is None or (static is not None and eff_cov < ecthreshold):
                     # Use static cutoff (low effective coverage, or dynamic cutoff undefined)
                     if count < static:
@@ -354,10 +358,10 @@ class ObservedProfile(Profile):
                     if count < avgcount * dynamic:
                         continue
                 gt.add(allele)
-            self.data['markers'][marker]['genotype'] = [
-                {'allele': a, 'haplotype': None} for a in sorted(gt)
+            self.data["markers"][marker]["genotype"] = [
+                {"allele": a, "haplotype": None} for a in sorted(gt)
             ]
 
     @property
     def gttype(self):
-        return 'ObservedProfile'
+        return "ObservedProfile"

--- a/microhapulator/seq.py
+++ b/microhapulator/seq.py
@@ -25,7 +25,7 @@ import microhapulator
 from microhapulator.profile import Profile
 
 
-SimulatedRead = namedtuple('SimulatedRead', ['identifier', 'sequence', 'quality'])
+SimulatedRead = namedtuple("SimulatedRead", ["identifier", "sequence", "quality"])
 
 
 def calc_n_reads_from_proportions(n, totalreads, prop):
@@ -33,59 +33,70 @@ def calc_n_reads_from_proportions(n, totalreads, prop):
         prop = [1.0 / n for _ in range(n)]
     else:
         if len(prop) != n:
-            raise ValueError('mismatch between contributor number and proportions')
+            raise ValueError("mismatch between contributor number and proportions")
     normprop = [x / sum(prop) for x in prop]
     return [int(totalreads * x) for x in normprop]
 
 
 def new_signature():
-    return ''.join([choice(list(ascii_letters + digits)) for _ in range(7)])
+    return "".join([choice(list(ascii_letters + digits)) for _ in range(7)])
 
 
 def sequencing(profile, seed=None, threads=1, numreads=500000, readsignature=None, readindex=0):
     tempdir = mkdtemp()
     try:
-        haplofile = tempdir + '/haplo.fasta'
-        with microhapulator.open(haplofile, 'w') as fh:
+        haplofile = tempdir + "/haplo.fasta"
+        with microhapulator.open(haplofile, "w") as fh:
             for defline, sequence in profile.haploseqs:
-                print('>', defline, '\n', sequence, sep='', file=fh)
+                print(">", defline, "\n", sequence, sep="", file=fh)
         isscmd = [
-            'iss', 'generate', '--n_reads', str(numreads), '--draft', haplofile,
-            '--model', 'MiSeq', '--output', tempdir + '/seq', '--quiet'
+            "iss",
+            "generate",
+            "--n_reads",
+            str(numreads),
+            "--draft",
+            haplofile,
+            "--model",
+            "MiSeq",
+            "--output",
+            tempdir + "/seq",
+            "--quiet",
         ]
         if seed:
-            isscmd.extend(['--seed', str(seed)])
+            isscmd.extend(["--seed", str(seed)])
         if threads:
-            isscmd.extend(['--cpus', str(threads)])
+            isscmd.extend(["--cpus", str(threads)])
         try:
             microhapulator.logstream.flush()
             fsync(microhapulator.logstream.fileno())
         except (AttributeError, OSError):  # pragma: no cover
             pass
         check_call(isscmd)
-        f1, f2 = tempdir + '/seq_R1.fastq', tempdir + '/seq_R2.fastq'
-        with open(f1, 'r') as infh1, open(f2, 'r') as infh2:
+        f1, f2 = tempdir + "/seq_R1.fastq", tempdir + "/seq_R2.fastq"
+        with open(f1, "r") as infh1, open(f2, "r") as infh2:
             if readsignature is None:
                 readsignature = new_signature()
             linebuffer = list()
             for line_r1, line_r2 in zip(infh1, infh2):
-                if line_r1.startswith('@mh'):
+                if line_r1.startswith("@mh"):
                     readindex += 1
-                    prefix = f'@{readsignature}:0:0:0:0:0:{readindex} 1:N:0:0 mh'
-                    line_r1 = line_r1.replace('@mh', prefix, 1)
-                    prefix = f'@{readsignature}:0:0:0:0:0:{readindex} 2:N:0:0 mh'
-                    line_r2 = line_r2.replace('@mh', prefix, 1)
-                    line_r1 = line_r1[:-3] + '\n'
-                    line_r2 = line_r2[:-3] + '\n'
+                    prefix = f"@{readsignature}:0:0:0:0:0:{readindex} 1:N:0:0 mh"
+                    line_r1 = line_r1.replace("@mh", prefix, 1)
+                    prefix = f"@{readsignature}:0:0:0:0:0:{readindex} 2:N:0:0 mh"
+                    line_r2 = line_r2.replace("@mh", prefix, 1)
+                    line_r1 = line_r1[:-3] + "\n"
+                    line_r2 = line_r2[:-3] + "\n"
                 linebuffer.append((line_r1, line_r2))
                 if len(linebuffer) == 4:
                     r1 = SimulatedRead(
-                        identifier=linebuffer[0][0], sequence=linebuffer[1][0],
-                        quality=linebuffer[3][0]
+                        identifier=linebuffer[0][0],
+                        sequence=linebuffer[1][0],
+                        quality=linebuffer[3][0],
                     )
                     r2 = SimulatedRead(
-                        identifier=linebuffer[0][1], sequence=linebuffer[1][1],
-                        quality=linebuffer[3][1]
+                        identifier=linebuffer[0][1],
+                        sequence=linebuffer[1][1],
+                        quality=linebuffer[3][1],
                     )
                     yield readindex, r1, r2
                     linebuffer = list()
@@ -96,20 +107,24 @@ def sequencing(profile, seed=None, threads=1, numreads=500000, readsignature=Non
 def seq(profiles, seeds=None, threads=1, totalreads=500000, proportions=None, sig=None):
     n = len(profiles)
     if seeds is None:
-        seeds = [randint(1, 2**32 - 1) for _ in range(n)]
+        seeds = [randint(1, 2 ** 32 - 1) for _ in range(n)]
     if len(seeds) != n:
-        raise ValueError('number of profiles must match number of seeds')
+        raise ValueError("number of profiles must match number of seeds")
     numreads = calc_n_reads_from_proportions(n, totalreads, proportions)
     if 0 in numreads:
-        raise ValueError('specified proportions result in 0 reads for 1 or more individuals')
+        raise ValueError("specified proportions result in 0 reads for 1 or more individuals")
     readsignature = sig if sig else new_signature()
     reads_sequenced = 0
     for profile, seed, nreads in zip(profiles, seeds, numreads):
-        message = 'Individual seed={seed} numreads={n}'.format(seed=seed, n=nreads)
-        microhapulator.plog('[MicroHapulator::seq]', message)
+        message = "Individual seed={seed} numreads={n}".format(seed=seed, n=nreads)
+        microhapulator.plog("[MicroHapulator::seq]", message)
         sequencer = sequencing(
-            profile, seed=seed, threads=threads, numreads=nreads,
-            readsignature=readsignature, readindex=reads_sequenced,
+            profile,
+            seed=seed,
+            threads=threads,
+            numreads=nreads,
+            readsignature=readsignature,
+            readindex=reads_sequenced,
         )
         for data in sequencer:
             yield data
@@ -127,18 +142,22 @@ def resolve_profiles(gtfiles):
 
 def main(args):
     if len(args.out) not in (1, 2):
-        raise ValueError(f'expected 1 or 2 output files, found {len(args.out)}')
+        raise ValueError(f"expected 1 or 2 output files, found {len(args.out)}")
     fh1 = fh2 = args.out[0]
     if len(args.out) == 2:
         fh2 = args.out[1]
     profiles = resolve_profiles(args.profiles)
     sequencer = seq(
-        profiles, seeds=args.seeds, threads=args.threads, totalreads=args.num_reads,
-        proportions=args.proportions, sig=args.signature
+        profiles,
+        seeds=args.seeds,
+        threads=args.threads,
+        totalreads=args.num_reads,
+        proportions=args.proportions,
+        sig=args.signature,
     )
     for n, read1, read2 in sequencer:
-        print(read1.identifier, read1.sequence, '+\n', read1.quality, sep='', end='', file=fh1)
-        print(read2.identifier, read2.sequence, '+\n', read2.quality, sep='', end='', file=fh2)
+        print(read1.identifier, read1.sequence, "+\n", read1.quality, sep="", end="", file=fh1)
+        print(read2.identifier, read2.sequence, "+\n", read2.quality, sep="", end="", file=fh2)
     for fh in args.out:
         if fh != sys.stdout:
             fh.close()

--- a/microhapulator/sim.py
+++ b/microhapulator/sim.py
@@ -20,7 +20,7 @@ def resolve_panel(panellist):
     panel = list()
     for value in panellist:
         if os.path.isfile(value):
-            with open(value, 'r') as fh:
+            with open(value, "r") as fh:
                 for line in fh:
                     panel.append(line.strip())
         else:
@@ -29,7 +29,7 @@ def resolve_panel(panellist):
 
 
 def sim(popids, panel, seed=None, relaxed=False):
-    '''Simulate a diploid genotype profile for the specified panel.
+    """Simulate a diploid genotype profile for the specified panel.
 
     For each locus in the panel simulate a diploid microhap profile. For each
     haplotype, alleles are selected according to population allele frequencies
@@ -37,39 +37,39 @@ def sim(popids, panel, seed=None, relaxed=False):
     population allele frequency data for a particular locus it is excluded
     (except in `relaxed` mode, in which case an allele is sampled from a
     uniform distribution).
-    '''
+    """
     haplopops = validate_populations(popids)
     markers = validate_markers(panel)
     if not relaxed:
         markers = exclude_markers_missing_freq_data(markers, haplopops)
     if len(markers) == 0:
-        raise ValueError('invalid panel: {}'.format(panel))
+        raise ValueError("invalid panel: {}".format(panel))
     profile = SimulatedProfile(ploidy=2)
     if seed is None:
-        seed = numpy.random.randint(2**32-1)
+        seed = numpy.random.randint(2 ** 32 - 1)
     numpy.random.seed(seed)
     for haplotype, locus, allele in sample_panel(haplopops, markers):
         profile.add(haplotype, locus, allele)
-    profile.data['metadata'] = {
-        'MaternalHaploPop': haplopops[0],
-        'PaternalHaploPop': haplopops[1],
-        'HaploSeed': seed,
+    profile.data["metadata"] = {
+        "MaternalHaploPop": haplopops[0],
+        "PaternalHaploPop": haplopops[1],
+        "HaploSeed": seed,
     }
-    message = 'simulated microhaplotype variation at {loc:d} markers'.format(loc=len(markers))
-    microhapulator.plog('[MicroHapulator::sim]', message)
+    message = "simulated microhaplotype variation at {loc:d} markers".format(loc=len(markers))
+    microhapulator.plog("[MicroHapulator::sim]", message)
     return profile
 
 
 def main(args):
     panel = resolve_panel(args.panel)
     profile = sim(args.popid, panel, seed=args.seed, relaxed=args.relaxed)
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         profile.dump(fh)
-        message = 'profile JSON written to {:s}'.format(fh.name)
-        microhapulator.plog('[MicroHapulator::sim]', message)
+        message = "profile JSON written to {:s}".format(fh.name)
+        microhapulator.plog("[MicroHapulator::sim]", message)
     if args.haplo_seq:
-        with microhapulator.open(args.haplo_seq, 'w') as fh:
+        with microhapulator.open(args.haplo_seq, "w") as fh:
             for defline, sequence in profile.haploseqs:
-                print('>', defline, '\n', sequence, sep='', file=fh)
-            message = 'haplotype sequences written to {:s}'.format(fh.name)
-            microhapulator.plog('[MicroHapulator::sim]', message)
+                print(">", defline, "\n", sequence, sep="", file=fh)
+            message = "haplotype sequences written to {:s}".format(fh.name)
+            microhapulator.plog("[MicroHapulator::sim]", message)

--- a/microhapulator/tests/__init__.py
+++ b/microhapulator/tests/__init__.py
@@ -13,6 +13,6 @@ from pkg_resources import resource_filename
 
 
 def data_file(path):
-    pathparts = path.split('/')
-    relpath = os.path.join('tests', 'data', *pathparts)
-    return resource_filename('microhapulator', relpath)
+    pathparts = path.split("/")
+    relpath = os.path.join("tests", "data", *pathparts)
+    return resource_filename("microhapulator", relpath)

--- a/microhapulator/tests/test_balance.py
+++ b/microhapulator/tests/test_balance.py
@@ -14,30 +14,30 @@ import pytest
 
 
 def test_balance_basic(capfd):
-    profile = Profile(fromfile=data_file('three-contrib-log.json'))
+    profile = Profile(fromfile=data_file("three-contrib-log.json"))
     obs_data = balance(profile)
-    exp_data = pandas.read_csv(data_file('three-contrib-log-balance.csv'))
+    exp_data = pandas.read_csv(data_file("three-contrib-log-balance.csv"))
     assert obs_data.equals(exp_data)
     terminal = capfd.readouterr()
-    assert 'MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 50.00' in terminal.out
+    assert "MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 50.00" in terminal.out
 
 
 def test_balance_cli(tmp_path, capfd):
-    outfile = str(tmp_path / 'balance.csv')
-    arglist = ['balance', '--csv', outfile, data_file('three-contrib-log.json')]
+    outfile = str(tmp_path / "balance.csv")
+    arglist = ["balance", "--csv", outfile, data_file("three-contrib-log.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.balance.main(args)
     obs_data = pandas.read_csv(outfile)
-    exp_data = pandas.read_csv(data_file('three-contrib-log-balance.csv'))
+    exp_data = pandas.read_csv(data_file("three-contrib-log-balance.csv"))
     assert obs_data.equals(exp_data)
     terminal = capfd.readouterr()
-    assert 'MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 50.00' in terminal.out
+    assert "MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 50.00" in terminal.out
 
 
 def test_balance_cli_no_discard(capfd):
-    arglist = ['balance', '--no-discarded', data_file('three-contrib-log.json')]
+    arglist = ["balance", "--no-discarded", data_file("three-contrib-log.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.balance.main(args)
     terminal = capfd.readouterr()
     print(terminal.out)
-    assert 'MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 40.00' in terminal.out
+    assert "MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 40.00" in terminal.out

--- a/microhapulator/tests/test_cli.py
+++ b/microhapulator/tests/test_cli.py
@@ -14,11 +14,11 @@ import pytest
 
 
 def test_microhapulator_open():
-    thefile = data_file('three-loci-refr.fasta')
-    with microhapulator.open(thefile, 'r') as filehandle:
+    thefile = data_file("three-loci-refr.fasta")
+    with microhapulator.open(thefile, "r") as filehandle:
         filecontents = filehandle.read()
-        assert len(filecontents.strip().split('\n')) == 6
+        assert len(filecontents.strip().split("\n")) == 6
 
     with pytest.raises(ValueError, match=r'invalid mode "p"') as ve:
-        with microhapulator.open(thefile, 'p') as filehandle:
+        with microhapulator.open(thefile, "p") as filehandle:
             pass

--- a/microhapulator/tests/test_contain.py
+++ b/microhapulator/tests/test_contain.py
@@ -14,11 +14,14 @@ import pytest
 from tempfile import NamedTemporaryFile
 
 
-@pytest.mark.parametrize('f1,f2,total,contained', [
-    ('four-brits-sim.json', 'one-brit-sim.json', 38, 38),
-    ('four-brits-sim.json', 'one-american-sim.json', 38, 31),
-    ('one-brit-sim.json', 'one-american-sim.json', 38, 11),
-])
+@pytest.mark.parametrize(
+    "f1,f2,total,contained",
+    [
+        ("four-brits-sim.json", "one-brit-sim.json", 38, 38),
+        ("four-brits-sim.json", "one-american-sim.json", 38, 31),
+        ("one-brit-sim.json", "one-american-sim.json", 38, 11),
+    ],
+)
 def test_contain(f1, f2, total, contained):
     profile1 = microhapulator.profile.Profile(data_file(f1))
     profile2 = microhapulator.profile.Profile(data_file(f2))
@@ -28,9 +31,7 @@ def test_contain(f1, f2, total, contained):
 
 
 def test_contain_cli(capsys):
-    arglist = [
-        'contain', data_file('one-brit-sim.json'), data_file('one-italian-sim.json')
-    ]
+    arglist = ["contain", data_file("one-brit-sim.json"), data_file("one-italian-sim.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.contain.main(args)
     terminal = capsys.readouterr()

--- a/microhapulator/tests/test_contrib.py
+++ b/microhapulator/tests/test_contrib.py
@@ -13,14 +13,17 @@ from microhapulator.tests import data_file
 import pytest
 
 
-@pytest.mark.parametrize('pjson,numcontrib', [
-    ('single-contrib-1.json', 1),
-    ('single-contrib-2.json', 1),
-    ('single-contrib-3.json', 1),
-    ('two-contrib-even.json', 2),
-    ('three-contrib-even.json', 3),
-    ('three-contrib-log.json', 3),
-])
+@pytest.mark.parametrize(
+    "pjson,numcontrib",
+    [
+        ("single-contrib-1.json", 1),
+        ("single-contrib-2.json", 1),
+        ("single-contrib-3.json", 1),
+        ("two-contrib-even.json", 2),
+        ("three-contrib-even.json", 3),
+        ("three-contrib-log.json", 3),
+    ],
+)
 def test_contrib_json(pjson, numcontrib):
     profile = microhapulator.contrib.load_profile(json=data_file(pjson))
     n, *data = microhapulator.contrib.contrib(profile)
@@ -28,8 +31,8 @@ def test_contrib_json(pjson, numcontrib):
 
 
 def test_contrib_bam():
-    bam = data_file('three-contrib-log.bam')
-    refr = data_file('default-panel.fasta.gz')
+    bam = data_file("three-contrib-log.bam")
+    refr = data_file("default-panel.fasta.gz")
     profile = microhapulator.contrib.load_profile(
         bamfile=bam, refrfasta=refr, dynamic=0.25, static=10
     )
@@ -38,9 +41,9 @@ def test_contrib_bam():
 
 
 def test_contrib_main(capsys):
-    bam = data_file('three-contrib-log.bam')
-    refr = data_file('default-panel.fasta.gz')
-    arglist = ['contrib', '-b', bam, '-r', refr, '--static', '10', '--dynamic', '0.25']
+    bam = data_file("three-contrib-log.bam")
+    refr = data_file("default-panel.fasta.gz")
+    arglist = ["contrib", "-b", bam, "-r", refr, "--static", "10", "--dynamic", "0.25"]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.contrib.main(args)
     out, err = capsys.readouterr()
@@ -48,8 +51,8 @@ def test_contrib_main(capsys):
 
 
 def test_main_no_op():
-    arglist = ['contrib']
+    arglist = ["contrib"]
     args = microhapulator.cli.get_parser().parse_args(arglist)
-    pattern = r'must provide either JSON profile or BAM and refr FASTA'
+    pattern = r"must provide either JSON profile or BAM and refr FASTA"
     with pytest.raises(ValueError, match=pattern) as ve:
         microhapulator.contrib.main(args)

--- a/microhapulator/tests/test_diff.py
+++ b/microhapulator/tests/test_diff.py
@@ -16,62 +16,95 @@ from tempfile import NamedTemporaryFile
 
 
 def test_diff_basic():
-    gt1 = SimulatedProfile(fromfile=data_file('diff-comp-1.json'))
-    gt2 = SimulatedProfile(fromfile=data_file('diff-comp-2.json'))
+    gt1 = SimulatedProfile(fromfile=data_file("diff-comp-1.json"))
+    gt2 = SimulatedProfile(fromfile=data_file("diff-comp-2.json"))
     diff = list(microhapulator.diff.diff(gt1, gt2))
     assert diff == [
-        ('MHDBL000140', {'C,C,A,A'}, {'C,C,T,A'}),
-        ('MHDBL000163', {'A,A,G,A,T'}, {'C,G,A,A,T'}),
+        ("MHDBL000140", {"C,C,A,A"}, {"C,C,T,A"}),
+        ("MHDBL000163", {"A,A,G,A,T"}, {"C,G,A,A,T"}),
     ]
 
 
 def test_diff_large():
-    gt1 = SimulatedProfile(fromfile=data_file('diff-comp-1.json'))
-    gt2 = SimulatedProfile(fromfile=data_file('diff-comp-3.json'))
+    gt1 = SimulatedProfile(fromfile=data_file("diff-comp-1.json"))
+    gt2 = SimulatedProfile(fromfile=data_file("diff-comp-3.json"))
     diff = list(microhapulator.diff.diff(gt1, gt2))
     loci = [d[0] for d in diff]
     print(diff[9], diff[17], diff[21])
     assert loci == [
-        'MHDBL000002', 'MHDBL000003', 'MHDBL000007', 'MHDBL000013', 'MHDBL000017', 'MHDBL000018',
-        'MHDBL000030', 'MHDBL000036', 'MHDBL000038', 'MHDBL000047', 'MHDBL000058', 'MHDBL000061',
-        'MHDBL000076', 'MHDBL000079', 'MHDBL000082', 'MHDBL000085', 'MHDBL000088', 'MHDBL000101',
-        'MHDBL000106', 'MHDBL000108', 'MHDBL000111', 'MHDBL000112', 'MHDBL000122', 'MHDBL000124',
-        'MHDBL000128', 'MHDBL000129', 'MHDBL000135', 'MHDBL000136', 'MHDBL000138', 'MHDBL000140',
-        'MHDBL000144', 'MHDBL000152', 'MHDBL000154', 'MHDBL000163', 'MHDBL000181', 'MHDBL000183',
-        'MHDBL000194', 'MHDBL000210', 'MHDBL000211', 'MHDBL000212'
+        "MHDBL000002",
+        "MHDBL000003",
+        "MHDBL000007",
+        "MHDBL000013",
+        "MHDBL000017",
+        "MHDBL000018",
+        "MHDBL000030",
+        "MHDBL000036",
+        "MHDBL000038",
+        "MHDBL000047",
+        "MHDBL000058",
+        "MHDBL000061",
+        "MHDBL000076",
+        "MHDBL000079",
+        "MHDBL000082",
+        "MHDBL000085",
+        "MHDBL000088",
+        "MHDBL000101",
+        "MHDBL000106",
+        "MHDBL000108",
+        "MHDBL000111",
+        "MHDBL000112",
+        "MHDBL000122",
+        "MHDBL000124",
+        "MHDBL000128",
+        "MHDBL000129",
+        "MHDBL000135",
+        "MHDBL000136",
+        "MHDBL000138",
+        "MHDBL000140",
+        "MHDBL000144",
+        "MHDBL000152",
+        "MHDBL000154",
+        "MHDBL000163",
+        "MHDBL000181",
+        "MHDBL000183",
+        "MHDBL000194",
+        "MHDBL000210",
+        "MHDBL000211",
+        "MHDBL000212",
     ]
-    assert diff[9] == ('MHDBL000047', set(), {'T,T'})
-    assert diff[17] == ('MHDBL000101', {'C,C,C,T'}, {'T,C,C,C'})
-    assert diff[21] == ('MHDBL000112', {'G,G,A,C'}, set())
+    assert diff[9] == ("MHDBL000047", set(), {"T,T"})
+    assert diff[17] == ("MHDBL000101", {"C,C,C,T"}, {"T,C,C,C"})
+    assert diff[21] == ("MHDBL000112", {"G,G,A,C"}, set())
 
 
 def test_diff_cli():
-    f1 = data_file('diff-comp-1.json')
-    f2 = data_file('diff-comp-3.json')
-    with NamedTemporaryFile(suffix='.json') as outfile:
-        arglist = ['diff', '-o', outfile.name, f1, f2]
+    f1 = data_file("diff-comp-1.json")
+    f2 = data_file("diff-comp-3.json")
+    with NamedTemporaryFile(suffix=".json") as outfile:
+        arglist = ["diff", "-o", outfile.name, f1, f2]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.diff.main(args)
-        with microhapulator.open(outfile.name, 'r') as fh:
+        with microhapulator.open(outfile.name, "r") as fh:
             output = fh.read().strip()
-        with microhapulator.open(data_file('diff-comp-1-3.txt'), 'r') as fh:
+        with microhapulator.open(data_file("diff-comp-1-3.txt"), "r") as fh:
             testoutput = fh.read().strip()
         assert output == testoutput
 
 
 def test_diff2():
-    gt1 = SimulatedProfile(fromfile=data_file('euramer-sim-gt.json'))
-    gt2 = SimulatedProfile(fromfile=data_file('euramer-inf-gt.json'))
+    gt1 = SimulatedProfile(fromfile=data_file("euramer-sim-gt.json"))
+    gt2 = SimulatedProfile(fromfile=data_file("euramer-inf-gt.json"))
     diff = list(microhapulator.diff.diff(gt1, gt2))
-    assert diff == [('MHDBL000018', set(), {'T,G,C,T,A'})]
+    assert diff == [("MHDBL000018", set(), {"T,G,C,T,A"})]
 
 
 def test_diff_nonmatching_alleles():
-    p1 = SimulatedProfile(fromfile=data_file('red-strict-profile.json'))
-    p2 = SimulatedProfile(fromfile=data_file('red-relaxed-profile.json'))
+    p1 = SimulatedProfile(fromfile=data_file("red-strict-profile.json"))
+    p2 = SimulatedProfile(fromfile=data_file("red-relaxed-profile.json"))
     diff = list(microhapulator.diff.diff(p1, p2))
     print(diff)
     assert diff == [
-        ('mh07CP-004', set(), {'T,T,T,A,T', 'A,A,T,A,T'}),
-        ('mh09KK-157', set(), {'G,C,C,A,T'}),
+        ("mh07CP-004", set(), {"T,T,T,A,T", "A,A,T,A,T"}),
+        ("mh09KK-157", set(), {"G,C,C,A,T"}),
     ]

--- a/microhapulator/tests/test_dist.py
+++ b/microhapulator/tests/test_dist.py
@@ -15,15 +15,18 @@ import pytest
 from tempfile import NamedTemporaryFile
 
 
-@pytest.mark.parametrize('gt1,gt2,dist', [
-    ('gujarati-ind1-gt.json', 'gujarati-ind1-gt.json', 0),
-    ('gujarati-ind1-gt.json', 'gujarati-ind2-gt.json', 2),
-    ('gujarati-ind1-gt.json', 'gujarati-ind3-gt.json', 1),
-    ('gujarati-ind1-gt.json', 'gujarati-ind4-gt.json', 3),
-    ('gujarati-ind2-gt.json', 'gujarati-ind3-gt.json', 3),
-    ('gujarati-ind2-gt.json', 'gujarati-ind4-gt.json', 3),
-    ('gujarati-ind3-gt.json', 'gujarati-ind4-gt.json', 2),
-])
+@pytest.mark.parametrize(
+    "gt1,gt2,dist",
+    [
+        ("gujarati-ind1-gt.json", "gujarati-ind1-gt.json", 0),
+        ("gujarati-ind1-gt.json", "gujarati-ind2-gt.json", 2),
+        ("gujarati-ind1-gt.json", "gujarati-ind3-gt.json", 1),
+        ("gujarati-ind1-gt.json", "gujarati-ind4-gt.json", 3),
+        ("gujarati-ind2-gt.json", "gujarati-ind3-gt.json", 3),
+        ("gujarati-ind2-gt.json", "gujarati-ind4-gt.json", 3),
+        ("gujarati-ind3-gt.json", "gujarati-ind4-gt.json", 2),
+    ],
+)
 def test_dist_gujarati(gt1, gt2, dist):
     g1 = ObservedProfile(data_file(gt1))
     g2 = ObservedProfile(data_file(gt2))
@@ -31,44 +34,50 @@ def test_dist_gujarati(gt1, gt2, dist):
 
 
 def test_dist_log_mixture():
-    f1 = data_file('murica/y-obs-genotype.json')
+    f1 = data_file("murica/y-obs-genotype.json")
     g1 = ObservedProfile(f1)
-    f2 = data_file('murica/y-sim-genotype.bed')
+    f2 = data_file("murica/y-sim-genotype.bed")
     g2 = SimulatedProfile.populate_from_bed(f2)
     assert microhapulator.dist.dist(g1, g2) == 19
     assert g1 != g2
 
 
 def test_dist_even_mixture():
-    with microhapulator.open(data_file('murica/x-obs-genotype.json'), 'r') as fh:
+    with microhapulator.open(data_file("murica/x-obs-genotype.json"), "r") as fh:
         g1 = ObservedProfile(fh)
-    f2 = data_file('murica/x-sim-genotype.bed')
+    f2 = data_file("murica/x-sim-genotype.bed")
     g2 = SimulatedProfile.populate_from_bed(f2)
     assert microhapulator.dist.dist(g1, g2) == 0
     assert g1 == g2
 
 
-@pytest.mark.parametrize('hdist', [0, 1, 2])
+@pytest.mark.parametrize("hdist", [0, 1, 2])
 def test_dist_sim_vs_obs(hdist):
     with NamedTemporaryFile() as outfile:
-        filename = 'murica/z-obs-genotype-dist{:d}.json'.format(hdist)
+        filename = "murica/z-obs-genotype-dist{:d}.json".format(hdist)
         arglist = [
-            'dist', '--out', outfile.name, data_file(filename),
-            data_file('murica/z-sim-genotype.json')
+            "dist",
+            "--out",
+            outfile.name,
+            data_file(filename),
+            data_file("murica/z-sim-genotype.json"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.dist.main(args)
-        with open(outfile.name, 'r') as fh:
+        with open(outfile.name, "r") as fh:
             assert json.load(fh) == {"hamming_distance": hdist}
 
 
 def test_dist_cli():
     with NamedTemporaryFile() as outfile:
         arglist = [
-            'dist', '--out', outfile.name, data_file('gujarati-ind2-gt.json'),
-            data_file('gujarati-ind3-gt.json')
+            "dist",
+            "--out",
+            outfile.name,
+            data_file("gujarati-ind2-gt.json"),
+            data_file("gujarati-ind3-gt.json"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.dist.main(args)
-        with open(outfile.name, 'r') as fh:
+        with open(outfile.name, "r") as fh:
             assert json.load(fh) == {"hamming_distance": 3}

--- a/microhapulator/tests/test_mix.py
+++ b/microhapulator/tests/test_mix.py
@@ -15,13 +15,17 @@ from tempfile import NamedTemporaryFile
 
 
 def test_mix_main():
-    with NamedTemporaryFile(suffix='.json.gz') as outfile:
+    with NamedTemporaryFile(suffix=".json.gz") as outfile:
         arglist = [
-            'mix', '--out', outfile.name, data_file('green-sim-gt-1.json.gz'),
-            data_file('green-sim-gt-2.json.gz'), data_file('green-sim-gt-3.json.gz')
+            "mix",
+            "--out",
+            outfile.name,
+            data_file("green-sim-gt-1.json.gz"),
+            data_file("green-sim-gt-2.json.gz"),
+            data_file("green-sim-gt-3.json.gz"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.mix.main(args)
         p = SimulatedProfile(fromfile=outfile.name)
-        testp = SimulatedProfile(fromfile=data_file('green-sim-gt-combined.json.gz'))
+        testp = SimulatedProfile(fromfile=data_file("green-sim-gt-combined.json.gz"))
         assert p == testp

--- a/microhapulator/tests/test_prob.py
+++ b/microhapulator/tests/test_prob.py
@@ -14,33 +14,34 @@ import pytest
 
 
 def test_rmp():
-    p = Profile(fromfile=data_file('korea-5loc.json'))
-    assert p.rand_match_prob('SA000936S') == pytest.approx(7.444E-09)
+    p = Profile(fromfile=data_file("korea-5loc.json"))
+    assert p.rand_match_prob("SA000936S") == pytest.approx(7.444e-09)
 
 
 def test_rmp_lrt():
-    p1 = Profile(fromfile=data_file('korea-5loc.json'))
-    p2 = Profile(fromfile=data_file('korea-5loc-1diff.json'))
-    assert p1.rmp_lr_test(p1, 'SA000936S') == pytest.approx(134332086.64194357)
-    assert p1.rmp_lr_test(p2, 'SA000936S') == pytest.approx(134332.08664194357)
+    p1 = Profile(fromfile=data_file("korea-5loc.json"))
+    p2 = Profile(fromfile=data_file("korea-5loc-1diff.json"))
+    assert p1.rmp_lr_test(p1, "SA000936S") == pytest.approx(134332086.64194357)
+    assert p1.rmp_lr_test(p2, "SA000936S") == pytest.approx(134332.08664194357)
 
 
-@pytest.mark.parametrize('altfile,lrvalue', [
-    ('korea-5loc-2diff-a.json', 121.4379),
-    ('korea-5loc-2diff-b.json', 1203.0258),
-    ('korea-5loc-2diff-c.json', 2136.9538),
-])
+@pytest.mark.parametrize(
+    "altfile,lrvalue",
+    [
+        ("korea-5loc-2diff-a.json", 121.4379),
+        ("korea-5loc-2diff-b.json", 1203.0258),
+        ("korea-5loc-2diff-c.json", 2136.9538),
+    ],
+)
 def test_rmp_lrt_2diff(altfile, lrvalue):
-    p1 = Profile(fromfile=data_file('korea-5loc.json'))
+    p1 = Profile(fromfile=data_file("korea-5loc.json"))
     p2 = Profile(fromfile=data_file(altfile))
-    assert p1.rmp_lr_test(p2, 'SA000936S') == pytest.approx(134.3321)
-    assert p2.rmp_lr_test(p1, 'SA000936S') == pytest.approx(lrvalue)
+    assert p1.rmp_lr_test(p2, "SA000936S") == pytest.approx(134.3321)
+    assert p2.rmp_lr_test(p1, "SA000936S") == pytest.approx(lrvalue)
 
 
 def test_prob_cli_rmp(capsys):
-    arglist = [
-        'prob', 'SA000936S', data_file('korea-5loc.json')
-    ]
+    arglist = ["prob", "SA000936S", data_file("korea-5loc.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.prob.main(args)
     terminal = capsys.readouterr()
@@ -50,7 +51,10 @@ def test_prob_cli_rmp(capsys):
 
 def test_prob_cli_lrt(capsys):
     arglist = [
-        'prob', 'SA000936S', data_file('korea-5loc.json'), data_file('korea-5loc-1diff.json')
+        "prob",
+        "SA000936S",
+        data_file("korea-5loc.json"),
+        data_file("korea-5loc-1diff.json"),
     ]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.prob.main(args)
@@ -60,23 +64,23 @@ def test_prob_cli_lrt(capsys):
 
 
 def test_prob_zero_freq():
-    p = Profile(fromfile=data_file('korea-5loc-zerofreq.json'))
-    assert p.rand_match_prob('SA000936S') == pytest.approx(2.3708e-11)
+    p = Profile(fromfile=data_file("korea-5loc-zerofreq.json"))
+    assert p.rand_match_prob("SA000936S") == pytest.approx(2.3708e-11)
 
 
 def test_prob_missing_freq():
-    p = Profile(fromfile=data_file('korea-5loc-missfreq.json'))
-    assert p.rand_match_prob('SA000936S') == pytest.approx(7.8360e-10)
+    p = Profile(fromfile=data_file("korea-5loc-missfreq.json"))
+    assert p.rand_match_prob("SA000936S") == pytest.approx(7.8360e-10)
 
 
 def test_bad_pop():
-    arglist = ['prob', 'Han', data_file('korea-5loc.json')]
+    arglist = ["prob", "Han", data_file("korea-5loc.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     message = r'issue with population "Han"; invalid or not unique'
     with pytest.raises(ValueError, match=message):
         microhapulator.prob.main(args)
 
-    arglist = ['prob', 'FakePopulation', data_file('korea-5loc.json')]
+    arglist = ["prob", "FakePopulation", data_file("korea-5loc.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     message = r'issue with population "FakePopulation"; invalid or not unique'
     with pytest.raises(ValueError, match=message):

--- a/microhapulator/tests/test_profile.py
+++ b/microhapulator/tests/test_profile.py
@@ -18,11 +18,11 @@ from tempfile import NamedTemporaryFile
 
 
 def test_profile_roundtrip():
-    seed = numpy.random.randint(1, 2**32 - 1)
-    print('DEBUG seed:', seed)
+    seed = numpy.random.randint(1, 2 ** 32 - 1)
+    print("DEBUG seed:", seed)
     numpy.random.seed(seed)
-    panel = ['mh01KK-072', 'mh17KK-014', 'mh05CP-006', 'mh04CP-007', 'mh14KK-101']
-    populations = ['SA004047P', 'SA004250L']
+    panel = ["mh01KK-072", "mh17KK-014", "mh05CP-006", "mh04CP-007", "mh14KK-101"]
+    populations = ["SA004047P", "SA004250L"]
     simulator = microhapulator.panel.sample_panel(populations, panel)
 
     profile = SimulatedProfile(ploidy=2)
@@ -39,84 +39,84 @@ def test_profile_roundtrip():
 
 
 def test_alleles():
-    simprof = SimulatedProfile.populate_from_bed(data_file('gttest.bed.gz'))
-    obsprof = ObservedProfile(fromfile=data_file('gttest.json'))
-    assert simprof.alleles('BoGuSlOcUs') == set()
-    assert obsprof.alleles('BoGuSlOcUs') == set()
-    assert simprof.alleles('MHDBL000135') == set(['G,C,T', 'G,T,C'])
-    assert obsprof.alleles('MHDBL000135') == set(['G,C,T', 'G,T,C'])
-    assert simprof.alleles('MHDBL000135', haplotype=0) == set(['G,C,T'])
-    assert simprof.alleles('MHDBL000135', haplotype=1) == set(['G,T,C'])
-    assert obsprof.alleles('MHDBL000135', haplotype=0) == set()
+    simprof = SimulatedProfile.populate_from_bed(data_file("gttest.bed.gz"))
+    obsprof = ObservedProfile(fromfile=data_file("gttest.json"))
+    assert simprof.alleles("BoGuSlOcUs") == set()
+    assert obsprof.alleles("BoGuSlOcUs") == set()
+    assert simprof.alleles("MHDBL000135") == set(["G,C,T", "G,T,C"])
+    assert obsprof.alleles("MHDBL000135") == set(["G,C,T", "G,T,C"])
+    assert simprof.alleles("MHDBL000135", haplotype=0) == set(["G,C,T"])
+    assert simprof.alleles("MHDBL000135", haplotype=1) == set(["G,T,C"])
+    assert obsprof.alleles("MHDBL000135", haplotype=0) == set()
 
 
 def test_haplotypes():
-    simprof = SimulatedProfile.populate_from_bed(data_file('gttest-mismatch1.bed.gz'))
+    simprof = SimulatedProfile.populate_from_bed(data_file("gttest-mismatch1.bed.gz"))
     assert simprof.haplotypes() == set([0, 1])
-    obsprof = ObservedProfile(data_file('pashtun-sim/test-output.json'))
+    obsprof = ObservedProfile(data_file("pashtun-sim/test-output.json"))
     assert obsprof.haplotypes() == set()
 
 
 def test_sim_obs_profile_equality():
-    simprof = SimulatedProfile.populate_from_bed(data_file('gttest.bed.gz'))
-    obsprof = ObservedProfile(fromfile=data_file('gttest.json'))
+    simprof = SimulatedProfile.populate_from_bed(data_file("gttest.bed.gz"))
+    obsprof = ObservedProfile(fromfile=data_file("gttest.json"))
     assert simprof == obsprof
     assert obsprof == simprof
 
 
 def test_sim_obs_profile_not_equal():
-    simprof1 = SimulatedProfile.populate_from_bed(data_file('gttest-mismatch1.bed.gz'))
+    simprof1 = SimulatedProfile.populate_from_bed(data_file("gttest-mismatch1.bed.gz"))
     assert simprof1 is not None
     assert simprof1 != 42
     assert simprof1 != 3.14159
-    assert simprof1 != 'A,C,C,T'
+    assert simprof1 != "A,C,C,T"
 
-    obsprof1 = ObservedProfile(fromfile=data_file('gttest.json'))
+    obsprof1 = ObservedProfile(fromfile=data_file("gttest.json"))
     assert simprof1 != obsprof1
     assert obsprof1 != simprof1
     assert obsprof1 != 1985
     assert obsprof1 != 98.6
 
-    simprof2 = SimulatedProfile.populate_from_bed(data_file('gttest-mismatch2.bed.gz'))
+    simprof2 = SimulatedProfile.populate_from_bed(data_file("gttest-mismatch2.bed.gz"))
     assert simprof1 != simprof2
     assert simprof2 != obsprof1
     assert obsprof1 != simprof2
 
-    obsprof2 = ObservedProfile(fromfile=data_file('gttest-altered.json'))
+    obsprof2 = ObservedProfile(fromfile=data_file("gttest-altered.json"))
     assert obsprof1 != obsprof2
 
 
 def test_merge_sim_genotypes():
     prof1 = SimulatedProfile()
-    prof1.add(0, 'mh11CP-004', 'C,G,G')
-    prof1.add(1, 'mh11CP-004', 'C,G,G')
-    prof1.add(0, 'mh05KK-123', 'A,C')
-    prof1.add(1, 'mh05KK-123', 'A,T')
+    prof1.add(0, "mh11CP-004", "C,G,G")
+    prof1.add(1, "mh11CP-004", "C,G,G")
+    prof1.add(0, "mh05KK-123", "A,C")
+    prof1.add(1, "mh05KK-123", "A,T")
     prof2 = SimulatedProfile()
-    prof2.add(0, 'mh11CP-004', 'C,T,A')
-    prof2.add(1, 'mh11CP-004', 'C,T,G')
-    prof2.add(0, 'mh05KK-123', 'A,T')
-    prof2.add(1, 'mh05KK-123', 'A,T')
+    prof2.add(0, "mh11CP-004", "C,T,A")
+    prof2.add(1, "mh11CP-004", "C,T,G")
+    prof2.add(0, "mh05KK-123", "A,T")
+    prof2.add(1, "mh05KK-123", "A,T")
     prof3 = SimulatedProfile()
-    prof3.add(0, 'mh11CP-004', 'C,G,G')
-    prof3.add(1, 'mh11CP-004', 'T,G,G')
-    prof3.add(0, 'mh05KK-123', 'G,C')
-    prof3.add(1, 'mh05KK-123', 'G,T')
+    prof3.add(0, "mh11CP-004", "C,G,G")
+    prof3.add(1, "mh11CP-004", "T,G,G")
+    prof3.add(0, "mh05KK-123", "G,C")
+    prof3.add(1, "mh05KK-123", "G,T")
 
     profile = SimulatedProfile.merge([prof1, prof2, prof3])
     print(profile.bedstr)
     assert profile.bedstr == (
-        'mh05KK-123\t121\t122\tA|A|A|A|G|G\n'
-        'mh05KK-123\t228\t229\tC|T|T|T|C|T\n'
-        'mh11CP-004\t162\t163\tC|C|C|C|C|T\n'
-        'mh11CP-004\t163\t164\tG|G|T|T|G|G\n'
-        'mh11CP-004\t187\t188\tG|G|A|G|G|G\n'
+        "mh05KK-123\t121\t122\tA|A|A|A|G|G\n"
+        "mh05KK-123\t228\t229\tC|T|T|T|C|T\n"
+        "mh11CP-004\t162\t163\tC|C|C|C|C|T\n"
+        "mh11CP-004\t163\t164\tG|G|T|T|G|G\n"
+        "mh11CP-004\t187\t188\tG|G|A|G|G|G\n"
     )
 
 
 def test_bed_error():
     p = SimulatedProfile()
-    p.add(0, 'BOGUS', 'A,C,C')
-    p.add(1, 'BOGUS', 'A,C,C')
+    p.add(0, "BOGUS", "A,C,C")
+    p.add(1, "BOGUS", "A,C,C")
     with pytest.raises(ValueError, match=r'unknown marker identifier "BOGUS"'):
         print(p.bedstr)

--- a/microhapulator/tests/test_seq.py
+++ b/microhapulator/tests/test_seq.py
@@ -19,26 +19,29 @@ import pytest
 from tempfile import NamedTemporaryFile
 
 
-@pytest.mark.parametrize('n,totalreads,prop,result', [
-    (3, 100, None, [33, 33, 33]),
-    (3, 100, [0.5, 0.4, 0.1], [50, 40, 10]),
-    (4, 4000000, [20, 30, 40, 50], [571428, 857142, 1142857, 1428571]),
-])
+@pytest.mark.parametrize(
+    "n,totalreads,prop,result",
+    [
+        (3, 100, None, [33, 33, 33]),
+        (3, 100, [0.5, 0.4, 0.1], [50, 40, 10]),
+        (4, 4000000, [20, 30, 40, 50], [571428, 857142, 1142857, 1428571]),
+    ],
+)
 def test_proportions(n, totalreads, prop, result):
     assert calc_n_reads_from_proportions(n, totalreads, prop) == result
 
 
 def test_proportions_failure_modes():
-    message = r'mismatch between contributor number and proportions'
+    message = r"mismatch between contributor number and proportions"
     with pytest.raises(ValueError, match=message) as ve:
         calc_n_reads_from_proportions(3, 1000, [0.6, 0.4])
 
 
 def test_even_mixture():
-    seed = numpy.random.randint(1, 2**32 - 1)
-    print('Seed:', seed)
+    seed = numpy.random.randint(1, 2 ** 32 - 1)
+    print("Seed:", seed)
     numpy.random.seed(seed)
-    popids = microhapdb.populations[microhapdb.populations.Source == '1KGP'].ID.unique()
+    popids = microhapdb.populations[microhapdb.populations.Source == "1KGP"].ID.unique()
     profiles = list()
     for _ in range(numpy.random.randint(2, 6)):
         pops = [numpy.random.choice(popids), numpy.random.choice(popids)]
@@ -60,70 +63,87 @@ def test_even_mixture():
 
 
 def test_complex_genotype(capsys):
-    profile = Profile(fromfile=data_file('mixture-genotype.json'))
+    profile = Profile(fromfile=data_file("mixture-genotype.json"))
     sequencer = microhapulator.seq.seq(list(profile.unmix()), totalreads=200)
     for n, read in enumerate(sequencer):
         pass
     terminal = capsys.readouterr()
-    assert terminal.err.count('Individual seed=') == 3
+    assert terminal.err.count("Individual seed=") == 3
 
 
 def test_uneven_mixture(capsys):
-    panel = ['mh01KK-001', 'mh01KK-205', 'mh01KK-117', 'mh10KK-163']
-    pops = ['SA004248S', 'SA004239S', 'SA001530J']
+    panel = ["mh01KK-001", "mh01KK-205", "mh01KK-117", "mh10KK-163"]
+    pops = ["SA004248S", "SA004239S", "SA001530J"]
     profiles = [microhapulator.sim.sim([popid], panel) for popid in pops]
-    sequencer = microhapulator.seq.seq(
-        profiles, totalreads=500, proportions=[0.5, 0.3, 0.2]
-    )
+    sequencer = microhapulator.seq.seq(profiles, totalreads=500, proportions=[0.5, 0.3, 0.2])
     for read in sequencer:
         pass
     terminal = capsys.readouterr()
-    assert 'numreads=250' in terminal.err
-    assert 'numreads=150' in terminal.err
-    assert 'numreads=100' in terminal.err
+    assert "numreads=250" in terminal.err
+    assert "numreads=150" in terminal.err
+    assert "numreads=100" in terminal.err
 
 
 def test_mixture_failure_modes():
-    panel = ['mh01KK-001', 'mh01KK-205', 'mh01KK-117', 'mh10KK-163']
-    pops = ['SA004248S', 'SA004239S', 'SA001530J']
+    panel = ["mh01KK-001", "mh01KK-205", "mh01KK-117", "mh10KK-163"]
+    pops = ["SA004248S", "SA004239S", "SA001530J"]
     profiles = [microhapulator.sim.sim([popid], panel) for popid in pops]
 
-    message = r'number of profiles must match number of seeds'
+    message = r"number of profiles must match number of seeds"
     with pytest.raises(ValueError, match=message) as ve:
         for read in microhapulator.seq.seq(profiles, seeds=[42, 1776]):
             pass
 
-    message = r'mismatch between contributor number and proportions'
+    message = r"mismatch between contributor number and proportions"
     with pytest.raises(ValueError, match=message) as ve:
         for read in microhapulator.seq.seq(profiles, proportions=[0.5, 0.3, 0.1, 0.1]):
             pass
 
-    message = r'specified proportions result in 0 reads for 1 or more individuals'
+    message = r"specified proportions result in 0 reads for 1 or more individuals"
     with pytest.raises(ValueError, match=message) as ve:
         for read in microhapulator.seq.seq(profiles, totalreads=500, proportions=[1, 100, 10000]):
             pass
 
 
 def test_main():
-    with NamedTemporaryFile(suffix='.fastq') as outfile:
+    with NamedTemporaryFile(suffix=".fastq") as outfile:
         arglist = [
-            'seq', '--out', outfile.name, '--seeds', '123454321', '--num-reads', '500',
-            '--signature', 'srd6Sei', data_file('orange-sim-profile.json')
+            "seq",
+            "--out",
+            outfile.name,
+            "--seeds",
+            "123454321",
+            "--num-reads",
+            "500",
+            "--signature",
+            "srd6Sei",
+            data_file("orange-sim-profile.json"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.seq.main(args)
-        assert filecmp.cmp(outfile.name, data_file('orange-reads.fastq'))
+        assert filecmp.cmp(outfile.name, data_file("orange-reads.fastq"))
 
 
-@pytest.mark.parametrize('relaxmode,gtfile,signature,testfile', [
-    (False, 'red-strict-profile.json', 'ihkSW9I', 'red-reads-strict.fastq'),
-    (True, 'red-relaxed-profile.json', 'kSW9IlM', 'red-reads-relaxed.fastq'),
-])
+@pytest.mark.parametrize(
+    "relaxmode,gtfile,signature,testfile",
+    [
+        (False, "red-strict-profile.json", "ihkSW9I", "red-reads-strict.fastq"),
+        (True, "red-relaxed-profile.json", "kSW9IlM", "red-reads-relaxed.fastq"),
+    ],
+)
 def test_main_relaxed(relaxmode, gtfile, signature, testfile):
-    with NamedTemporaryFile(suffix='.fastq') as outfile:
+    with NamedTemporaryFile(suffix=".fastq") as outfile:
         arglist = [
-            'seq', '--out', outfile.name, '--seeds', '24680', '--num-reads', '100',
-            '--signature', signature, data_file(gtfile)
+            "seq",
+            "--out",
+            outfile.name,
+            "--seeds",
+            "24680",
+            "--num-reads",
+            "100",
+            "--signature",
+            signature,
+            data_file(gtfile),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         args.relaxed = relaxmode
@@ -132,78 +152,90 @@ def test_main_relaxed(relaxmode, gtfile, signature, testfile):
 
 
 def test_main_no_seed():
-    with NamedTemporaryFile(suffix='.fastq') as outfile:
+    with NamedTemporaryFile(suffix=".fastq") as outfile:
         arglist = [
-            'seq', '--out', outfile.name, '--num-reads', '200',
-            data_file('orange-sim-profile.json')
+            "seq",
+            "--out",
+            outfile.name,
+            "--num-reads",
+            "200",
+            data_file("orange-sim-profile.json"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.seq.main(args)
-        with open(outfile.name, 'r') as fh:
-            filelines = fh.read().strip().split('\n')
+        with open(outfile.name, "r") as fh:
+            filelines = fh.read().strip().split("\n")
             assert len(filelines) == 800  # 200 reads * 4 lines per read = 800 lines
 
 
 def test_main_mixture(capsys):
     arglist = [
-        'seq', '--seeds', '42', '1776', '--proportions', '0.8', '0.2', '--num-reads', '500',
-        data_file('yellow-mix-gt.json')
+        "seq",
+        "--seeds",
+        "42",
+        "1776",
+        "--proportions",
+        "0.8",
+        "0.2",
+        "--num-reads",
+        "500",
+        data_file("yellow-mix-gt.json"),
     ]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.seq.main(args)
     terminal = capsys.readouterr()
-    outlines = terminal.out.strip().split('\n')
+    outlines = terminal.out.strip().split("\n")
     nrecords = len(outlines) / 4
     assert nrecords == pytest.approx(500, abs=25)
     assert outlines[-3] == (
-        'TCAATTCAATTTCTACCCTCAGCATCAAGGCAGGGGTTCATCATAATGGGTATTGGAGGCTCAAAGAAA'
-        'ATTTAGGCTCAGCACACACACACACACACACACACACACACAGCGATTTTTAATGCTGGTACAATCACA'
-        'GGAGACTGCAACCCAGCCCTCCTCAGCGCCTCGGGTGCTCACGGGCACTCCTGGAGTCTCGGCCACACT'
-        'AAGTCCCCCTGGTGGCCACACAGAAGAAGAGGTGGTAAAACTTTCTGGGAGTGAGTTCAAAAATTTTAG'
-        'GAGTCTAAAAACATACTTTTCTAAG'
+        "TCAATTCAATTTCTACCCTCAGCATCAAGGCAGGGGTTCATCATAATGGGTATTGGAGGCTCAAAGAAA"
+        "ATTTAGGCTCAGCACACACACACACACACACACACACACACAGCGATTTTTAATGCTGGTACAATCACA"
+        "GGAGACTGCAACCCAGCCCTCCTCAGCGCCTCGGGTGCTCACGGGCACTCCTGGAGTCTCGGCCACACT"
+        "AAGTCCCCCTGGTGGCCACACAGAAGAAGAGGTGGTAAAACTTTCTGGGAGTGAGTTCAAAAATTTTAG"
+        "GAGTCTAAAAACATACTTTTCTAAG"
     )
 
 
 def test_main_out_stdout(capsys):
-    arglist = ['seq', '--num-reads', '100', data_file('orange-sim-profile.json')]
+    arglist = ["seq", "--num-reads", "100", data_file("orange-sim-profile.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.seq.main(args)
     terminal = capsys.readouterr()
-    outlines = terminal.out.strip().split('\n')
+    outlines = terminal.out.strip().split("\n")
     nrecords = len(outlines) / 4
     assert nrecords == pytest.approx(100, abs=5)
 
 
 def test_main_out_one_filename(tmp_path):
-    outfile = str(tmp_path / 'reads-interleaved.fastq')
-    arglist = ['seq', '--out', outfile, '--num-reads', '100', data_file('orange-sim-profile.json')]
+    outfile = str(tmp_path / "reads-interleaved.fastq")
+    arglist = ["seq", "--out", outfile, "--num-reads", "100", data_file("orange-sim-profile.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.seq.main(args)
     assert os.path.isfile(outfile)
-    with open(outfile, 'r') as fh:
-        outlines = fh.read().strip().split('\n')
+    with open(outfile, "r") as fh:
+        outlines = fh.read().strip().split("\n")
         nrecords = len(outlines) / 4
         assert nrecords == pytest.approx(100, abs=5)
 
 
 def test_main_out_two_filenames(tmp_path):
-    f1 = str(tmp_path / 'reads-R1.fastq')
-    f2 = str(tmp_path / 'reads-R2.fastq')
-    arglist = ['seq', '--out', f1, f2, '--num-reads', '100', data_file('orange-sim-profile.json')]
+    f1 = str(tmp_path / "reads-R1.fastq")
+    f2 = str(tmp_path / "reads-R2.fastq")
+    arglist = ["seq", "--out", f1, f2, "--num-reads", "100", data_file("orange-sim-profile.json")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.seq.main(args)
     assert os.path.isfile(f1)
     assert os.path.isfile(f2)
     for fn in (f1, f2):
-        with open(fn, 'r') as fh:
-            outlines = fh.read().strip().split('\n')
+        with open(fn, "r") as fh:
+            outlines = fh.read().strip().split("\n")
             nrecords = len(outlines) / 4
             assert nrecords == pytest.approx(50, abs=5)
 
 
 def test_main_out_three_filenames(capsys):
-    arglist = ['seq', '--out', 'ONE', 'TWO', 'THREE', '--', data_file('orange-sim-profile.json')]
+    arglist = ["seq", "--out", "ONE", "TWO", "THREE", "--", data_file("orange-sim-profile.json")]
     with pytest.raises(SystemExit):
         args = microhapulator.cli.get_parser().parse_args(arglist)
     terminal = capsys.readouterr()
-    assert 'expected 1 or 2 output filenames, got 3' in terminal.err
+    assert "expected 1 or 2 output filenames, got 3" in terminal.err

--- a/microhapulator/tests/test_sim.py
+++ b/microhapulator/tests/test_sim.py
@@ -18,82 +18,181 @@ import tempfile
 
 def test_meaning_of_life():
     panel = [
-        'mh01KK-205', 'mh01CP-016', 'mh01KK-117', 'mh10CP-003', 'mh10KK-170', 'mh10KK-101',
-        'mh11KK-180', 'mh11KK-037', 'mh11KK-191', 'mh12CP-008', 'mh12KK-202', 'mh12KK-046',
-        'mh13KK-213', 'mh13KK-223', 'mh14CP-003', 'mh14KK-048', 'mh15KK-069', 'mh15KK-104',
-        'mh16KK-255', 'mh17CP-001', 'mh17KK-052', 'mh17KK-055', 'mh18CP-005', 'mh18KK-293',
-        'mh19KK-299', 'mh19KK-057', 'mh02KK-138', 'mh02KK-136', 'mh20KK-307', 'mh20KK-058',
-        'mh21KK-315', 'mh22KK-060', 'mh22KK-061', 'mh03CP-005', 'mh03KK-007', 'mh03KK-150',
-        'mh04KK-030', 'mh04KK-013', 'mh04KK-017', 'mh05KK-020', 'mh06CP-007', 'mh06KK-008',
-        'mh07CP-004', 'mh07KK-030', 'mh07KK-031', 'mh08KK-039', 'mh08KK-032', 'mh09KK-033',
-        'mh09KK-153', 'mh09KK-157',
+        "mh01KK-205",
+        "mh01CP-016",
+        "mh01KK-117",
+        "mh10CP-003",
+        "mh10KK-170",
+        "mh10KK-101",
+        "mh11KK-180",
+        "mh11KK-037",
+        "mh11KK-191",
+        "mh12CP-008",
+        "mh12KK-202",
+        "mh12KK-046",
+        "mh13KK-213",
+        "mh13KK-223",
+        "mh14CP-003",
+        "mh14KK-048",
+        "mh15KK-069",
+        "mh15KK-104",
+        "mh16KK-255",
+        "mh17CP-001",
+        "mh17KK-052",
+        "mh17KK-055",
+        "mh18CP-005",
+        "mh18KK-293",
+        "mh19KK-299",
+        "mh19KK-057",
+        "mh02KK-138",
+        "mh02KK-136",
+        "mh20KK-307",
+        "mh20KK-058",
+        "mh21KK-315",
+        "mh22KK-060",
+        "mh22KK-061",
+        "mh03CP-005",
+        "mh03KK-007",
+        "mh03KK-150",
+        "mh04KK-030",
+        "mh04KK-013",
+        "mh04KK-017",
+        "mh05KK-020",
+        "mh06CP-007",
+        "mh06KK-008",
+        "mh07CP-004",
+        "mh07KK-030",
+        "mh07KK-031",
+        "mh08KK-039",
+        "mh08KK-032",
+        "mh09KK-033",
+        "mh09KK-153",
+        "mh09KK-157",
     ]
-    profile = microhapulator.sim.sim(['SA004250L', 'SA004250L'], panel, seed=42)
-    testprofile = SimulatedProfile(fromfile=data_file('meaning-of-life.json.gz'))
+    profile = microhapulator.sim.sim(["SA004250L", "SA004250L"], panel, seed=42)
+    testprofile = SimulatedProfile(fromfile=data_file("meaning-of-life.json.gz"))
     assert profile == testprofile
 
 
-@pytest.mark.parametrize('relaxmode,testfile', [
-    (False, 'red-strict-profile.json'),
-    (True, 'red-relaxed-profile.json'),
-])
+@pytest.mark.parametrize(
+    "relaxmode,testfile",
+    [
+        (False, "red-strict-profile.json"),
+        (True, "red-relaxed-profile.json"),
+    ],
+)
 def test_sim_relaxed(relaxmode, testfile):
     profile = microhapulator.sim.sim(
-        ['SA000101C'], ['mh01KK-117', 'mh09KK-157', 'mh07CP-004'],
-        seed=54321, relaxed=relaxmode
+        ["SA000101C"], ["mh01KK-117", "mh09KK-157", "mh07CP-004"], seed=54321, relaxed=relaxmode
     )
     testprofile = SimulatedProfile(fromfile=data_file(testfile))
     assert profile == testprofile
 
 
 def test_main():
-    with tempfile.NamedTemporaryFile(suffix='-profile.json') as outfile:
+    with tempfile.NamedTemporaryFile(suffix="-profile.json") as outfile:
         arglist = [
-            'sim', '--out', outfile.name, '--seed', '1985', 'SA004250L', 'SA004250L',
-            'mh13KK-218', 'mh05KK-170', 'mh21KK-320', 'mh10KK-163', 'mh10KK-169', 'mh02KK-134',
-            'mh16KK-049', 'mh06KK-008', 'mh21KK-324', 'mh11KK-180', 'mh13KK-217', 'mh21KK-315',
-            'mh04KK-030', 'mh01KK-117', 'mh19KK-299', 'mh01KK-205', 'mh13KK-223', 'mh02KK-136',
-            'mh04KK-013', 'mh13KK-213', 'mh16KK-255', 'mh20KK-307', 'mh09KK-157', 'mh13KK-225',
-            'mh22KK-061', 'mh18KK-293', 'mh03KK-150', 'mh01KK-001', 'mh21KK-316', 'mh11KK-191',
-            'mh01NK-001', 'mh12KK-202', 'mh09KK-153', 'mh17KK-272', 'mh16KK-302', 'mh09KK-152',
-            'mh10KK-170', 'mh09KK-033', 'mh20KK-058', 'mh11KK-187', 'mh04KK-017', 'mh01KK-172',
-            'mh06KK-030', 'mh18KK-285', 'mh01KK-106', 'mh06KK-025', 'mh02KK-004', 'mh09KK-020',
-            'mh07KK-030', 'mh02KK-213'
+            "sim",
+            "--out",
+            outfile.name,
+            "--seed",
+            "1985",
+            "SA004250L",
+            "SA004250L",
+            "mh13KK-218",
+            "mh05KK-170",
+            "mh21KK-320",
+            "mh10KK-163",
+            "mh10KK-169",
+            "mh02KK-134",
+            "mh16KK-049",
+            "mh06KK-008",
+            "mh21KK-324",
+            "mh11KK-180",
+            "mh13KK-217",
+            "mh21KK-315",
+            "mh04KK-030",
+            "mh01KK-117",
+            "mh19KK-299",
+            "mh01KK-205",
+            "mh13KK-223",
+            "mh02KK-136",
+            "mh04KK-013",
+            "mh13KK-213",
+            "mh16KK-255",
+            "mh20KK-307",
+            "mh09KK-157",
+            "mh13KK-225",
+            "mh22KK-061",
+            "mh18KK-293",
+            "mh03KK-150",
+            "mh01KK-001",
+            "mh21KK-316",
+            "mh11KK-191",
+            "mh01NK-001",
+            "mh12KK-202",
+            "mh09KK-153",
+            "mh17KK-272",
+            "mh16KK-302",
+            "mh09KK-152",
+            "mh10KK-170",
+            "mh09KK-033",
+            "mh20KK-058",
+            "mh11KK-187",
+            "mh04KK-017",
+            "mh01KK-172",
+            "mh06KK-030",
+            "mh18KK-285",
+            "mh01KK-106",
+            "mh06KK-025",
+            "mh02KK-004",
+            "mh09KK-020",
+            "mh07KK-030",
+            "mh02KK-213",
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.sim.main(args)
         p = SimulatedProfile(fromfile=outfile.name)
-        testp = SimulatedProfile(fromfile=data_file('bitusa-profile.json'))
+        testp = SimulatedProfile(fromfile=data_file("bitusa-profile.json"))
         assert p == testp
 
 
 def test_main_haplo_seq(tmp_path):
-    profile = str(tmp_path / 'profile.json')
-    hapseq = str(tmp_path / 'haplo.fasta')
+    profile = str(tmp_path / "profile.json")
+    hapseq = str(tmp_path / "haplo.fasta")
     arglist = [
-        'sim', '--seed', '293847', '--out', profile, '--haplo-seq', hapseq,
-        'SA004047P', 'SA004047P', 'mh07CP-004', 'mh14CP-003'
+        "sim",
+        "--seed",
+        "293847",
+        "--out",
+        profile,
+        "--haplo-seq",
+        hapseq,
+        "SA004047P",
+        "SA004047P",
+        "mh07CP-004",
+        "mh14CP-003",
     ]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.sim.main(args)
     p = SimulatedProfile(fromfile=profile)
-    testp = SimulatedProfile(fromfile=data_file('orange-sim-profile.json'))
+    testp = SimulatedProfile(fromfile=data_file("orange-sim-profile.json"))
     assert p == testp
-    assert filecmp.cmp(hapseq, data_file('orange-haplo.fasta'))
+    assert filecmp.cmp(hapseq, data_file("orange-haplo.fasta"))
 
 
 def test_no_seed():
-    genotype = microhapulator.sim.sim(['SA004047P'], ['mh07CP-004', 'mh14CP-003'])
-    assert len(genotype.data['markers']) == 2
-    assert sorted(genotype.data['markers']) == ['mh07CP-004', 'mh14CP-003']
+    genotype = microhapulator.sim.sim(["SA004047P"], ["mh07CP-004", "mh14CP-003"])
+    assert len(genotype.data["markers"]) == 2
+    assert sorted(genotype.data["markers"]) == ["mh07CP-004", "mh14CP-003"]
 
 
 def test_bad_panel():
-    with pytest.raises(ValueError, match=r'invalid panel') as ve:
-        microhapulator.sim.sim(['SA004047P'], ['DUUUUDE', 'SWEEEET'])
+    with pytest.raises(ValueError, match=r"invalid panel") as ve:
+        microhapulator.sim.sim(["SA004047P"], ["DUUUUDE", "SWEEEET"])
 
 
 def test_panel_file():
-    arglist = ['sim', 'Pashtun', 'Pashtun', data_file('minipanel.txt')]
+    arglist = ["sim", "Pashtun", "Pashtun", data_file("minipanel.txt")]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.sim.main(args)

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -17,67 +17,73 @@ from tempfile import NamedTemporaryFile
 
 
 def test_type_simple():
-    bam = data_file('pashtun-sim/aligned-reads.bam')
-    fasta = data_file('pashtun-sim/tiny-panel.fasta.gz')
+    bam = data_file("pashtun-sim/aligned-reads.bam")
+    fasta = data_file("pashtun-sim/tiny-panel.fasta.gz")
     gt = microhapulator.type.type(bam, fasta, static=10, dynamic=0.25)
-    testgtfile = data_file('pashtun-sim/test-output.json')
+    testgtfile = data_file("pashtun-sim/test-output.json")
     testgt = ObservedProfile(fromfile=testgtfile)
     assert gt == testgt
 
 
 def test_type_simpler():
-    bam = data_file('pashtun-sim/aligned-reads.bam')
-    fasta = data_file('pashtun-sim/tiny-panel.fasta.gz')
+    bam = data_file("pashtun-sim/aligned-reads.bam")
+    fasta = data_file("pashtun-sim/tiny-panel.fasta.gz")
     gt = microhapulator.type.type(bam, fasta)
-    testgtfile = data_file('pashtun-sim/test-output-sans-genotype.json')
+    testgtfile = data_file("pashtun-sim/test-output-sans-genotype.json")
     testgt = ObservedProfile(fromfile=testgtfile)
     assert gt == testgt
 
 
 def test_type_missing_bam_index(tmp_path):
-    bam = data_file('three-contrib-log-link.bam')
-    fasta = data_file('default-panel.fasta.gz')
-    tmp_bam = str(tmp_path / 'three-contrib-log-link.bam')
-    tmp_fasta = str(tmp_path / 'default-panel.fasta.gz')
+    bam = data_file("three-contrib-log-link.bam")
+    fasta = data_file("default-panel.fasta.gz")
+    tmp_bam = str(tmp_path / "three-contrib-log-link.bam")
+    tmp_fasta = str(tmp_path / "default-panel.fasta.gz")
     copyfile(bam, tmp_bam)
     copyfile(fasta, tmp_fasta)
     gt = microhapulator.type.type(tmp_bam, tmp_fasta, minbasequal=13)
-    ac30 = gt.data['markers']['MHDBL000030']['allele_counts']
-    ac197 = gt.data['markers']['MHDBL000197']['allele_counts']
-    assert ac30 == {'A,A,T,C': 3, 'A,C,C,C': 2, 'A,C,C,G': 18, 'G,C,C,C': 1, 'G,C,C,G': 34}
-    assert ac197 == {'A,A,T,T,T': 30, 'A,A,T,T,C': 39, 'A,A,T,A,T': 1, 'A,A,T,A,C': 1}
+    ac30 = gt.data["markers"]["MHDBL000030"]["allele_counts"]
+    ac197 = gt.data["markers"]["MHDBL000197"]["allele_counts"]
+    assert ac30 == {"A,A,T,C": 3, "A,C,C,C": 2, "A,C,C,G": 18, "G,C,C,C": 1, "G,C,C,G": 34}
+    assert ac197 == {"A,A,T,T,T": 30, "A,A,T,T,C": 39, "A,A,T,A,T": 1, "A,A,T,A,C": 1}
 
 
 def test_type_cli_simple():
     with NamedTemporaryFile() as outfile:
         arglist = [
-            'type', '--out', outfile.name, '--static', '5', '--dynamic', '0.25',
-            data_file('pashtun-sim/tiny-panel.fasta.gz'),
-            data_file('pashtun-sim/aligned-reads.bam'),
+            "type",
+            "--out",
+            outfile.name,
+            "--static",
+            "5",
+            "--dynamic",
+            "0.25",
+            data_file("pashtun-sim/tiny-panel.fasta.gz"),
+            data_file("pashtun-sim/aligned-reads.bam"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.type.main(args)
-        testgtfile = data_file('pashtun-sim/test-output.json')
+        testgtfile = data_file("pashtun-sim/test-output.json")
         gtdata = ObservedProfile(fromfile=outfile.name)
         testgtdata = ObservedProfile(fromfile=testgtfile)
         assert gtdata == testgtdata
 
 
 def test_type_dyn_cutoff():
-    bam = data_file('dyncut-test-reads.bam')
-    fasta = data_file('dyncut-panel.fasta.gz')
+    bam = data_file("dyncut-test-reads.bam")
+    fasta = data_file("dyncut-panel.fasta.gz")
 
     gt = microhapulator.type.type(bam, fasta, static=10, dynamic=0.25)
-    assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G'])
-    assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
+    assert gt.alleles("MHDBL000018") == set(["C,A,C,T,G", "T,G,C,T,G"])
+    assert gt.alleles("MHDBL000156") == set(["T,C,A,C", "T,C,G,G"])
 
     gt = microhapulator.type.type(bam, fasta, static=4, dynamic=0.25)
-    assert gt.alleles('MHDBL000018') == set(['C,A,C,T,G', 'T,G,C,T,G', 'C,A,C,T,A', 'T,G,C,T,A'])
-    assert gt.alleles('MHDBL000156') == set(['T,C,A,C', 'T,C,G,G'])
+    assert gt.alleles("MHDBL000018") == set(["C,A,C,T,G", "T,G,C,T,G", "C,A,C,T,A", "T,G,C,T,A"])
+    assert gt.alleles("MHDBL000156") == set(["T,C,A,C", "T,C,G,G"])
 
 
 def test_type_no_var_offsets():
-    bam = data_file('sandawe-dad.bam')
-    fasta = data_file('sandawe-panel.fasta.gz')
-    with pytest.raises(ValueError, match=r'variant offsets not annotated for target amplicon:'):
+    bam = data_file("sandawe-dad.bam")
+    fasta = data_file("sandawe-panel.fasta.gz")
+    with pytest.raises(ValueError, match=r"variant offsets not annotated for target amplicon:"):
         profile = microhapulator.type.type(bam, fasta)

--- a/microhapulator/tests/test_unite.py
+++ b/microhapulator/tests/test_unite.py
@@ -15,10 +15,13 @@ import pytest
 from tempfile import NamedTemporaryFile
 
 
-@pytest.mark.parametrize('momgt,dadgt,kidgt,seed', [
-    ('green-mom-1-gt.json', 'green-dad-1-gt.json', 'green-kid-1-gt.json', 110517),
-    ('green-mom-2-gt.json', 'green-dad-2-gt.json', 'green-kid-2-gt.json', 111017),
-])
+@pytest.mark.parametrize(
+    "momgt,dadgt,kidgt,seed",
+    [
+        ("green-mom-1-gt.json", "green-dad-1-gt.json", "green-kid-1-gt.json", 110517),
+        ("green-mom-2-gt.json", "green-dad-2-gt.json", "green-kid-2-gt.json", 111017),
+    ],
+)
 def test_unite_basic(momgt, dadgt, kidgt, seed):
     mom = Profile(fromfile=data_file(momgt))
     dad = Profile(fromfile=data_file(dadgt))
@@ -29,29 +32,34 @@ def test_unite_basic(momgt, dadgt, kidgt, seed):
 
 
 def test_unite_unshared(capsys):
-    mom = Profile(fromfile=data_file('swedish-mom.json'))
-    dad = Profile(fromfile=data_file('swedish-dad.json'))
+    mom = Profile(fromfile=data_file("swedish-mom.json"))
+    dad = Profile(fromfile=data_file("swedish-dad.json"))
     kid = Profile.unite(mom, dad)
     terminal = capsys.readouterr()
-    message = 'markers not common to mom and dad profiles are excluded'
+    message = "markers not common to mom and dad profiles are excluded"
     assert message in terminal.err
 
 
 def test_unite_none_shared(capsys):
-    mom = Profile(fromfile=data_file('sandawe-mom.json'))
-    dad = Profile(fromfile=data_file('sandawe-dad.json'))
-    with pytest.raises(ValueError, match=r'mom and dad profiles have no markers in common'):
+    mom = Profile(fromfile=data_file("sandawe-mom.json"))
+    dad = Profile(fromfile=data_file("sandawe-dad.json"))
+    with pytest.raises(ValueError, match=r"mom and dad profiles have no markers in common"):
         kid = Profile.unite(mom, dad)
 
 
 def test_unite_cli():
-    with NamedTemporaryFile(suffix='.json') as outfile:
+    with NamedTemporaryFile(suffix=".json") as outfile:
         arglist = [
-            'unite', '--seed', '113817', '--out', outfile.name,
-            data_file('green-mom-3-gt.json'), data_file('green-dad-3-gt.json'),
+            "unite",
+            "--seed",
+            "113817",
+            "--out",
+            outfile.name,
+            data_file("green-mom-3-gt.json"),
+            data_file("green-dad-3-gt.json"),
         ]
         args = microhapulator.cli.get_parser().parse_args(arglist)
         microhapulator.unite.main(args)
         p = Profile(fromfile=outfile.name)
-        testp = Profile(fromfile=data_file('green-kid-3-gt.json'))
+        testp = Profile(fromfile=data_file("green-kid-3-gt.json"))
         assert p == testp

--- a/microhapulator/unite.py
+++ b/microhapulator/unite.py
@@ -20,5 +20,5 @@ def main(args):
         Profile(fromfile=args.mom),
         Profile(fromfile=args.dad),
     )
-    with microhapulator.open(args.out, 'w') as fh:
+    with microhapulator.open(args.out, "w") as fh:
         profile.dump(fh)

--- a/setup.py
+++ b/setup.py
@@ -10,39 +10,35 @@
 from setuptools import setup
 import versioneer
 
-with open('README.md', 'r') as infile:
+with open("README.md", "r") as infile:
     longdesc = infile.read()
 
 setup(
-    name='microhapulator',
+    name="microhapulator",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    description='Software package for simulating and analyzing microhaplotype sequence data',
+    description="Software package for simulating and analyzing microhaplotype sequence data",
     long_description=longdesc,
-    long_description_content_type='text/markdown',
-    url='https://github.com/bioforensics/microhapulator',
-    author='Daniel Standage',
-    author_email='daniel.standage@nbacc.dhs.gov',
-    packages=['microhapulator', 'microhapulator.cli', 'microhapulator.tests'],
+    long_description_content_type="text/markdown",
+    url="https://github.com/bioforensics/microhapulator",
+    author="Daniel Standage",
+    author_email="daniel.standage@nbacc.dhs.gov",
+    packages=["microhapulator", "microhapulator.cli", "microhapulator.tests"],
     package_data={
-        'microhapulator': [
-            'microhapulator/tests/data/*', 'microhapulator/tests/data/*/*'
-        ]
+        "microhapulator": ["microhapulator/tests/data/*", "microhapulator/tests/data/*/*"]
     },
     include_package_data=True,
-    install_requires=['insilicoseq', 'numpy', 'microhapdb', 'happer', 'jsonschema', 'termgraph'],
-    entry_points={
-        'console_scripts': ['mhpl8r = microhapulator.__main__:main']
-    },
+    install_requires=["insilicoseq", "numpy", "microhapdb", "happer", "jsonschema", "termgraph"],
+    entry_points={"console_scripts": ["mhpl8r = microhapulator.__main__:main"]},
     classifiers=[
-        'Environment :: Console',
-        'Framework :: IPython',
-        'Framework :: Jupyter',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Legal Industry',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3',
-        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        "Environment :: Console",
+        "Framework :: IPython",
+        "Framework :: Jupyter",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Legal Industry",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
     zip_safe=True,
 )


### PR DESCRIPTION
Updating the Makefile to use Black instead of pycodestyle/pep8 for style checks and autoformatting. No functional changes, just formatting/style.

Also dropped support for Python 3.6 since it doesn't support the minimum version of pandas required for MicroHapDB.

Closes #89.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- ~~Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)~~
