### PR TITLE
Pin minimum dependency versions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,8 +18,6 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/bioforensics/happer.git
-        pip install git+https://github.com/bioforensics/MicroHapDB.git
         pip install .
         make devdeps
     - name: Test with pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Corrected a bug with Fastq headers in `mhpl8r seq` module (#71).
 - Corrected a bug resulting from attempting to do set operations on `None` (#75).
 - Corrected a bug with RMP implementation (#86).
+- Set minimum versions for runtime dependencies (#97).
 
 ## [0.4] 2019-11-05
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test4:
 devdeps:
 	pip install --upgrade pip setuptools
 	pip install wheel twine
-	pip install 'black==21.12b0' 'pytest>=5.0' pytest-cov pytest-sugar
+	pip install 'black==21.12b0' 'pytest>=6.0' pytest-cov pytest-xdist pytest-sugar
 
 
 ## devhooks:  install development hooks

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,13 @@ setup(
         "microhapulator": ["microhapulator/tests/data/*", "microhapulator/tests/data/*/*"]
     },
     include_package_data=True,
-    install_requires=["insilicoseq", "numpy", "happer", "jsonschema", "termgraph"],
+    install_requires=[
+        "happer>=0.1",
+        "insilicoseq>=1.5.2",
+        "jsonschema>=4.0",
+        "numpy>=1.19",
+        "termgraph>=0.5",
+    ],
     entry_points={"console_scripts": ["mhpl8r = microhapulator.__main__:main"]},
     classifiers=[
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "insilicoseq>=1.5.2",
         "jsonschema>=4.0",
         "numpy>=1.19",
+        "pandas>1.0",
         "termgraph>=0.5",
     ],
     entry_points={"console_scripts": ["mhpl8r = microhapulator.__main__:main"]},


### PR DESCRIPTION
Thread #90 proposes the use of `environment.yml` files for declaring runtime and development dependencies, based on a recent focus on Conda for configuring development and deployment environments. However, the motivating use case (CI deployment) is accomplished much more quickly using `setup.py` and installing dependencies from PyPI. This PR updates `setup.py` to pin minimum versions for runtime dependencies, and we'll continue to use the current configuration strategy: PyPI for CI builds, Conda installation for end users, and PyPI/Makefile for developers.

Close #90.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
