### PR TITLE
Update "ObservedProfile" terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Changed the default pysam pileup `max_depth` parameter, overriding 8000 with 1e6 and exposing as a hidden CLI parameter (#87).
 - Removed dependency on MicroHapDB for marker definitions, frequencies, and sequences (#93).
 - Refactored CLI and Python API and added new `microhapulator.op` subpackage to serve as main API entry point (#98).
+- Replaced the "ObservedProfile" terminology with the more appropriate "TypingResult" (#99).
 
 ### Fixed
 - Corrected a bug with Fastq headers in `mhpl8r seq` module (#71).

--- a/microhapulator/cli/balance.py
+++ b/microhapulator/cli/balance.py
@@ -11,7 +11,7 @@
 # -------------------------------------------------------------------------------------------------
 
 from microhapulator.op import balance
-from microhapulator.profile import ObservedProfile
+from microhapulator.profile import TypingResult
 
 
 def subparser(subparsers):
@@ -30,7 +30,7 @@ def subparser(subparsers):
 
 
 def main(args):
-    profile = ObservedProfile(fromfile=args.input)
-    data = balance(profile, include_discarded=args.discarded)
+    result = TypingResult(fromfile=args.input)
+    data = balance(result, include_discarded=args.discarded)
     if args.csv:
         data.to_csv(args.csv, index=False)

--- a/microhapulator/op/type.py
+++ b/microhapulator/op/type.py
@@ -74,10 +74,10 @@ def type(
         bam.references, offsets.keys(), "read alignments", "marker definitions"
     )
     genotyper = tally_haplotypes(bam, offsets, minbasequal=minbasequal, max_depth=max_depth)
-    profile = microhapulator.profile.ObservedProfile()
+    result = microhapulator.profile.TypingResult()
     for locusid, cov_by_pos, htcounts, ndiscarded in genotyper:
-        profile.record_coverage(locusid, cov_by_pos, ndiscarded=ndiscarded)
+        result.record_coverage(locusid, cov_by_pos, ndiscarded=ndiscarded)
         for allele, count in htcounts.items():
-            profile.record_allele(locusid, allele, count)
-    profile.infer(ecthreshold=ecthreshold, static=static, dynamic=dynamic)
-    return profile
+            result.record_allele(locusid, allele, count)
+    result.infer(ecthreshold=ecthreshold, static=static, dynamic=dynamic)
+    return result

--- a/microhapulator/profile-schema.json
+++ b/microhapulator/profile-schema.json
@@ -26,7 +26,7 @@
             "enum": [
                 "base",
                 "SimulatedProfile",
-                "ObservedProfile"
+                "TypingResult"
             ]
         },
         "markers": {

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -287,9 +287,9 @@ class SimulatedProfile(Profile):
         return "SimulatedProfile"
 
 
-class ObservedProfile(Profile):
+class TypingResult(Profile):
     def __init__(self, fromfile=None):
-        super(ObservedProfile, self).__init__(fromfile=fromfile)
+        super(TypingResult, self).__init__(fromfile=fromfile)
 
     def record_coverage(self, marker, cov_by_pos, ndiscarded=0):
         self.data["markers"][marker] = {
@@ -336,4 +336,4 @@ class ObservedProfile(Profile):
 
     @property
     def gttype(self):
-        return "ObservedProfile"
+        return "TypingResult"

--- a/microhapulator/tests/data/murica/x-obs-genotype.json
+++ b/microhapulator/tests/data/murica/x-obs-genotype.json
@@ -683,5 +683,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/murica/y-obs-genotype.json
+++ b/microhapulator/tests/data/murica/y-obs-genotype.json
@@ -554,5 +554,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/murica/z-obs-genotype-dist0.json
+++ b/microhapulator/tests/data/murica/z-obs-genotype-dist0.json
@@ -432,5 +432,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/murica/z-obs-genotype-dist1.json
+++ b/microhapulator/tests/data/murica/z-obs-genotype-dist1.json
@@ -432,5 +432,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/murica/z-obs-genotype-dist2.json
+++ b/microhapulator/tests/data/murica/z-obs-genotype-dist2.json
@@ -432,5 +432,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/pashtun-sim/test-output-sans-genotype.json
+++ b/microhapulator/tests/data/pashtun-sim/test-output-sans-genotype.json
@@ -40,6 +40,6 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile",
+    "type": "TypingResult",
     "version": "0.4.1+26.gf268e39.dirty"
 }

--- a/microhapulator/tests/data/pashtun-sim/test-output.json
+++ b/microhapulator/tests/data/pashtun-sim/test-output.json
@@ -71,6 +71,6 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile",
+    "type": "TypingResult",
     "version": "0.4.1+32.g3f663a8.dirty"
 }

--- a/microhapulator/tests/data/prof/euramer-inf-gt.json
+++ b/microhapulator/tests/data/prof/euramer-inf-gt.json
@@ -1151,5 +1151,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/gttest-altered.json
+++ b/microhapulator/tests/data/prof/gttest-altered.json
@@ -975,5 +975,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/gttest.json
+++ b/microhapulator/tests/data/prof/gttest.json
@@ -980,5 +980,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/gujarati-ind1-gt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind1-gt.json
@@ -94,5 +94,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/gujarati-ind2-gt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind2-gt.json
@@ -85,5 +85,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/gujarati-ind3-gt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind3-gt.json
@@ -87,5 +87,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/gujarati-ind4-gt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind4-gt.json
@@ -82,5 +82,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/single-contrib-1.json
+++ b/microhapulator/tests/data/prof/single-contrib-1.json
@@ -515,5 +515,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/single-contrib-2.json
+++ b/microhapulator/tests/data/prof/single-contrib-2.json
@@ -472,5 +472,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/single-contrib-3.json
+++ b/microhapulator/tests/data/prof/single-contrib-3.json
@@ -523,5 +523,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/three-contrib-even.json
+++ b/microhapulator/tests/data/prof/three-contrib-even.json
@@ -848,5 +848,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/three-contrib-log.json
+++ b/microhapulator/tests/data/prof/three-contrib-log.json
@@ -570,5 +570,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/data/prof/two-contrib-even.json
+++ b/microhapulator/tests/data/prof/two-contrib-even.json
@@ -689,5 +689,5 @@
         }
     },
     "ploidy": null,
-    "type": "ObservedProfile"
+    "type": "TypingResult"
 }

--- a/microhapulator/tests/test_dist.py
+++ b/microhapulator/tests/test_dist.py
@@ -12,7 +12,7 @@
 
 import json
 import microhapulator
-from microhapulator.profile import ObservedProfile, SimulatedProfile
+from microhapulator.profile import TypingResult, SimulatedProfile
 from microhapulator.tests import data_file
 import pytest
 from tempfile import NamedTemporaryFile
@@ -31,27 +31,24 @@ from tempfile import NamedTemporaryFile
     ],
 )
 def test_dist_gujarati(gt1, gt2, dist):
-    g1 = ObservedProfile(data_file(gt1))
-    g2 = ObservedProfile(data_file(gt2))
-    assert microhapulator.op.dist(g1, g2) == dist
+    r1 = TypingResult(data_file(gt1))
+    r2 = TypingResult(data_file(gt2))
+    assert microhapulator.op.dist(r1, r2) == dist
 
 
 def test_dist_log_mixture():
-    f1 = data_file("murica/y-obs-genotype.json")
-    g1 = ObservedProfile(f1)
-    f2 = data_file("murica/y-sim-genotype.bed")
-    g2 = SimulatedProfile.populate_from_bed(f2)
-    assert microhapulator.op.dist(g1, g2) == 19
-    assert g1 != g2
+    p1 = TypingResult(data_file("murica/y-obs-genotype.json"))
+    p2 = SimulatedProfile.populate_from_bed(data_file("murica/y-sim-genotype.bed"))
+    assert microhapulator.op.dist(p1, p2) == 19
+    assert p1 != p2
 
 
 def test_dist_even_mixture():
     with microhapulator.open(data_file("murica/x-obs-genotype.json"), "r") as fh:
-        g1 = ObservedProfile(fh)
-    f2 = data_file("murica/x-sim-genotype.bed")
-    g2 = SimulatedProfile.populate_from_bed(f2)
-    assert microhapulator.op.dist(g1, g2) == 0
-    assert g1 == g2
+        p1 = TypingResult(fh)
+    p2 = SimulatedProfile.populate_from_bed(data_file("murica/x-sim-genotype.bed"))
+    assert microhapulator.op.dist(p1, p2) == 0
+    assert p1 == p2
 
 
 @pytest.mark.parametrize("hdist", [0, 1, 2])

--- a/microhapulator/tests/test_profile.py
+++ b/microhapulator/tests/test_profile.py
@@ -11,7 +11,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import microhapulator
-from microhapulator.profile import SimulatedProfile, ObservedProfile
+from microhapulator.profile import SimulatedProfile, TypingResult
 from microhapulator.tests import data_file
 import numpy
 import pandas as pd
@@ -30,28 +30,28 @@ def test_profile_roundtrip(tmp_path):
 
 def test_alleles():
     simprof = SimulatedProfile.populate_from_bed(data_file("gttest.bed.gz"))
-    obsprof = ObservedProfile(fromfile=data_file("prof/gttest.json"))
+    typeprof = TypingResult(fromfile=data_file("prof/gttest.json"))
     assert simprof.alleles("BoGuSlOcUs") == set()
-    assert obsprof.alleles("BoGuSlOcUs") == set()
+    assert typeprof.alleles("BoGuSlOcUs") == set()
     assert simprof.alleles("MHDBL000135") == set(["G,C,T", "G,T,C"])
-    assert obsprof.alleles("MHDBL000135") == set(["G,C,T", "G,T,C"])
+    assert typeprof.alleles("MHDBL000135") == set(["G,C,T", "G,T,C"])
     assert simprof.alleles("MHDBL000135", haplotype=0) == set(["G,C,T"])
     assert simprof.alleles("MHDBL000135", haplotype=1) == set(["G,T,C"])
-    assert obsprof.alleles("MHDBL000135", haplotype=0) == set()
+    assert typeprof.alleles("MHDBL000135", haplotype=0) == set()
 
 
 def test_haplotypes():
     simprof = SimulatedProfile.populate_from_bed(data_file("gttest-mismatch1.bed.gz"))
     assert simprof.haplotypes() == set([0, 1])
-    obsprof = ObservedProfile(data_file("pashtun-sim/test-output.json"))
-    assert obsprof.haplotypes() == set()
+    typeprof = TypingResult(data_file("pashtun-sim/test-output.json"))
+    assert typeprof.haplotypes() == set()
 
 
 def test_sim_obs_profile_equality():
     simprof = SimulatedProfile.populate_from_bed(data_file("gttest.bed.gz"))
-    obsprof = ObservedProfile(fromfile=data_file("prof/gttest.json"))
-    assert simprof == obsprof
-    assert obsprof == simprof
+    typeprof = TypingResult(fromfile=data_file("prof/gttest.json"))
+    assert simprof == typeprof
+    assert typeprof == simprof
 
 
 def test_sim_obs_profile_not_equal():
@@ -61,19 +61,19 @@ def test_sim_obs_profile_not_equal():
     assert simprof1 != 3.14159
     assert simprof1 != "A,C,C,T"
 
-    obsprof1 = ObservedProfile(fromfile=data_file("prof/gttest.json"))
-    assert simprof1 != obsprof1
-    assert obsprof1 != simprof1
-    assert obsprof1 != 1985
-    assert obsprof1 != 98.6
+    typeprof1 = TypingResult(fromfile=data_file("prof/gttest.json"))
+    assert simprof1 != typeprof1
+    assert typeprof1 != simprof1
+    assert typeprof1 != 1985
+    assert typeprof1 != 98.6
 
     simprof2 = SimulatedProfile.populate_from_bed(data_file("gttest-mismatch2.bed.gz"))
     assert simprof1 != simprof2
-    assert simprof2 != obsprof1
-    assert obsprof1 != simprof2
+    assert simprof2 != typeprof1
+    assert typeprof1 != simprof2
 
-    obsprof2 = ObservedProfile(fromfile=data_file("prof/gttest-altered.json"))
-    assert obsprof1 != obsprof2
+    typeprof2 = TypingResult(fromfile=data_file("prof/gttest-altered.json"))
+    assert typeprof1 != typeprof2
 
 
 def test_merge_sim_genotypes():

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -11,7 +11,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import microhapulator
-from microhapulator.profile import ObservedProfile
+from microhapulator.profile import TypingResult
 from microhapulator.tests import data_file
 import pytest
 from shutil import copyfile
@@ -21,7 +21,7 @@ def test_type_simple():
     bam = data_file("pashtun-sim/aligned-reads.bam")
     tsv = data_file("pashtun-sim/tiny-panel.tsv")
     observed = microhapulator.op.type(bam, tsv, static=10, dynamic=0.25)
-    expected = ObservedProfile(fromfile=data_file("pashtun-sim/test-output.json"))
+    expected = TypingResult(fromfile=data_file("pashtun-sim/test-output.json"))
     assert observed == expected
 
 
@@ -29,7 +29,7 @@ def test_type_simpler():
     bam = data_file("pashtun-sim/aligned-reads.bam")
     tsv = data_file("pashtun-sim/tiny-panel.tsv")
     observed = microhapulator.op.type(bam, tsv)
-    expected = ObservedProfile(fromfile=data_file("pashtun-sim/test-output-sans-genotype.json"))
+    expected = TypingResult(fromfile=data_file("pashtun-sim/test-output-sans-genotype.json"))
     assert observed == expected
 
 
@@ -62,8 +62,8 @@ def test_type_cli_simple(tmp_path):
     ]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.cli.type.main(args)
-    observed = ObservedProfile(fromfile=outfile)
-    expected = ObservedProfile(fromfile=data_file("pashtun-sim/test-output.json"))
+    observed = TypingResult(fromfile=outfile)
+    expected = TypingResult(fromfile=data_file("pashtun-sim/test-output.json"))
     assert observed == expected
 
 


### PR DESCRIPTION
Initial iterations of the MicroHapulator code referred to simulated and inferred/observed genotypes, and then profiles. This PR maintains the "SimulatedProfile" terminology in the code, but replaced "ObservedProfile" with "TypingResult" which is the more commonly used term of art. Closes #95.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
