### PR TITLE
Improvements to QA/QC for interlocus balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## Unreleased
+
+### Changed
+- Interlocus balance code updated to support generating high-resolution graphics and performing a chid-square goodness-of-fit test (#121).
+
+
 ## [0.5] 2022-01-20
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,6 @@ clean:
 style:
 	black --line-length=99 --check microhapulator/*.py microhapulator/*/*.py setup.py
 
-## format:     autoformat Python code
+## format:    autoformat Python code
 format:
 	black --line-length=99 microhapulator/*.py microhapulator/*/*.py setup.py

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test4:
 devdeps:
 	pip install --upgrade pip setuptools
 	pip install wheel twine
-	pip install 'black==21.12b0' 'pytest>=6.0' pytest-cov pytest-xdist pytest-sugar myst-parser sphinx sphinx-argparse
+	pip install 'black==22.3' 'pytest>=6.0' pytest-cov pytest-xdist pytest-sugar myst-parser sphinx sphinx-argparse
 
 ## doc:       build HTML documentation
 doc:

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -314,7 +314,7 @@ def seq(
     """
     n = len(profiles)
     if seeds is None:
-        seeds = [np.random.randint(1, 2 ** 32 - 1) for _ in range(n)]
+        seeds = [np.random.randint(1, 2**32 - 1) for _ in range(n)]
     if len(seeds) != n:
         raise ValueError("number of profiles must match number of seeds")
     numreads = calc_n_reads_from_proportions(n, totalreads, proportions)
@@ -350,7 +350,7 @@ def sim(frequencies, seed=None):
     """
     profile = SimulatedProfile(ploidy=2)
     if seed is None:
-        seed = np.random.randint(2 ** 32 - 1)
+        seed = np.random.randint(2**32 - 1)
     profile.data["metadata"] = {
         "HaploSeed": seed,
     }

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -96,7 +96,15 @@ def balance(
             plt.ylabel("Reads Mapped (× 1000)")
         else:
             plt.ylabel("Reads Mapped and Typed (× 1000)")
-        plt.title("Interlocus Balance", color=color)
+        ax = plt.gca()
+        ax.yaxis.grid(True, color="#DDDDDD")
+        ax.set_axisbelow(True)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.spines["left"].set_visible(False)
+        ax.spines["bottom"].set_color("#CCCCCC")
+        ax.tick_params(left=False)
+        plt.title("Interlocus Balance")
         plt.savefig(tofile)
     return chisq, data
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -21,7 +21,6 @@ import os
 import pandas as pd
 import pysam
 import re
-import seaborn
 from shutil import rmtree
 from string import ascii_letters, digits
 from subprocess import check_call, run

--- a/microhapulator/cli/balance.py
+++ b/microhapulator/cli/balance.py
@@ -27,11 +27,52 @@ def subparser(subparsers):
         "are mapped to the marker but discarded because they do not span all variants at the "
         "marker are included",
     )
+    cli.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="do not print interlocus balance histogram to standard output in ASCII",
+    )
+    cli.add_argument(
+        "--figure",
+        metavar="FILE",
+        default=None,
+        help="plot interlocus balance histogram to FILE using Matplotlib; image format is inferred from extension of provided file name",
+    )
+    cli.add_argument(
+        "--figsize",
+        metavar=("W", "H"),
+        nargs=2,
+        type=float,
+        default=(6, 4),
+        help="dimensions (width × height in inches) of the image file to be generated; 6 4 by default",
+    )
+    cli.add_argument(
+        "--dpi",
+        metavar="DPI",
+        type=int,
+        default=200,
+        help="resolution (in dots per inch) of the image file to be generated; DPI=200 by default",
+    )
+    cli.add_argument(
+        "--color",
+        metavar="COL",
+        default="#1f77b4",
+        help="color of the histogram to be generated in the image file; COL='#1f77b4' by default",
+    )
     cli.add_argument("input", help="a typing result including haplotype counts in JSON format")
 
 
 def main(args):
     result = TypingResult(fromfile=args.input)
-    data = mhapi.balance(result, include_discarded=args.discarded)
+    data = mhapi.balance(
+        result,
+        include_discarded=args.discarded,
+        terminal=not args.quiet,
+        tofile=args.figure,
+        figsize=args.figsize,
+        dpi=args.dpi,
+        color=args.color,
+    )
     if args.csv:
         data.to_csv(args.csv, index=False)

--- a/microhapulator/cli/balance.py
+++ b/microhapulator/cli/balance.py
@@ -16,7 +16,16 @@ from microhapulator.profile import TypingResult
 
 
 def subparser(subparsers):
-    cli = subparsers.add_parser("balance", description="Compute interlocus balance")
+    desc = (
+        "Plot interlocus balance in the terminal and/or a high-resolution graphic. Also normalize "
+        "read counts and perform a chi-square goodness-of-fit test assuming uniform read coverage "
+        "across markers. The reported chi-square statistic measures the extent of imbalance, and "
+        "can be compared among samples sequenced using the same panel: the minimum value of 0 "
+        "represents perfectly uniform coverage, while the maximum value of D occurs when all "
+        "reads map to a single marker (D represents the degrees of freedom, or the number of "
+        "markers minus 1)."
+    )
+    cli = subparsers.add_parser("balance", description=desc)
     cli.add_argument("-c", "--csv", metavar="FILE", help="write read counts to FILE in CSV format")
     cli.add_argument(
         "-D",
@@ -65,7 +74,7 @@ def subparser(subparsers):
 
 def main(args):
     result = TypingResult(fromfile=args.input)
-    data = mhapi.balance(
+    chisq, data = mhapi.balance(
         result,
         include_discarded=args.discarded,
         terminal=not args.quiet,
@@ -74,5 +83,6 @@ def main(args):
         dpi=args.dpi,
         color=args.color,
     )
+    print(f"Extent of imbalance (chi-square statistic): {chisq:.4f}")
     if args.csv:
         data.to_csv(args.csv, index=False)

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -159,7 +159,7 @@ class Profile(object):
                 mismatches += 1
             else:
                 mismatches += 2
-        numerator = erate ** mismatches
+        numerator = erate**mismatches
         denominator = self.rand_match_prob(freqs)
         return numerator / denominator
 

--- a/microhapulator/tests/test_balance.py
+++ b/microhapulator/tests/test_balance.py
@@ -20,9 +20,10 @@ import pytest
 
 def test_balance_basic(capfd):
     profile = Profile(fromfile=data_file("prof/three-contrib-log.json"))
-    obs_data = mhapi.balance(profile)
+    chisq, obs_data = mhapi.balance(profile)
     exp_data = pandas.read_csv(data_file("three-contrib-log-balance.csv"))
     assert obs_data.equals(exp_data)
+    assert chisq == pytest.approx(0.00928395)
     terminal = capfd.readouterr()
     assert "MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 50.00" in terminal.out
 
@@ -36,6 +37,8 @@ def test_balance_cli(tmp_path, capfd):
     exp_data = pandas.read_csv(data_file("three-contrib-log-balance.csv"))
     assert obs_data.equals(exp_data)
     terminal = capfd.readouterr()
+    print(terminal.out)
+    assert "Extent of imbalance (chi-square statistic): 0.0093" in terminal.out
     assert "MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 50.00" in terminal.out
 
 
@@ -45,4 +48,5 @@ def test_balance_cli_no_discard(capfd):
     microhapulator.cli.balance.main(args)
     terminal = capfd.readouterr()
     print(terminal.out)
+    assert "Extent of imbalance (chi-square statistic): 0.0221" in terminal.out
     assert "MHDBL000212: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 40.00" in terminal.out

--- a/microhapulator/tests/test_profile.py
+++ b/microhapulator/tests/test_profile.py
@@ -19,7 +19,7 @@ import pytest
 
 
 def test_profile_roundtrip(tmp_path):
-    seed = numpy.random.randint(1, 2 ** 32 - 1)
+    seed = numpy.random.randint(1, 2**32 - 1)
     freqs = pd.read_csv(data_file("freq/asw5-freq.tsv"), sep="\t")
     profile = mhapi.sim(freqs, seed=seed)
     profile.dump(tmp_path / "profile.json")

--- a/microhapulator/tests/test_seq.py
+++ b/microhapulator/tests/test_seq.py
@@ -40,7 +40,7 @@ def test_proportions_failure_modes():
 
 
 def test_even_mixture():
-    seed = numpy.random.randint(1, 2 ** 32 - 1)
+    seed = numpy.random.randint(1, 2**32 - 1)
     print("Seed:", seed)
     numpy.random.seed(seed)
     freqs = microhapulator.load_marker_frequencies(data_file("freq/acb-dozen-freq.tsv"))

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "happer>=0.1",
         "insilicoseq>=1.5.2",
         "jsonschema>=4.0",
+        "matplotlib>=3.0",
         "numpy>=1.19",
         "pandas>1.0",
         "termgraph>=0.5",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "matplotlib>=3.0",
         "numpy>=1.19",
         "pandas>1.0",
-        "scipy>=1.8",
+        "scipy>=1.7",
         "termgraph>=0.5",
     ],
     entry_points={"console_scripts": ["mhpl8r = microhapulator.cli:main"]},

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "matplotlib>=3.0",
         "numpy>=1.19",
         "pandas>1.0",
+        "scipy>=1.8",
         "termgraph>=0.5",
     ],
     entry_points={"console_scripts": ["mhpl8r = microhapulator.cli:main"]},


### PR DESCRIPTION
This PR adds several improvements to `microhapulator.api.balance()` and the corresponding `mhpl8r balance` command for computing interlocus balance. Now, in addition to printing histogram in ASCII text to the terminal, there is support for generating a high-resolution plot suitable for reports or documents. MicroHapulator also now performs a chi-square goodness of fit test, with an assumption of uniform coverage across markers, using normalized read counts. The reported chi-square statistic measures the extent of imbalance, and can be compared among samples sequenced using the same panel: the minimum value of 0 represents perfectly uniform coverage, while the maximum value of *D* occurs when all reads map to a single marker (*D* is the degrees of freedom, or the number of markers minus 1).

```
$ mhpl8r balance B1-type.json --figure example.png
[MicroHapulator] running version 0.5+6.gd5dabce.dirty

mh17KK-054: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 14.07K
mh14KK-048: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 13.86K
mh01KK-106: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 12.44K
mh06KK-008: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 10.90K
mh11KK-187: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 10.88K
mh03KK-020: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 10.33K
mh01KK-117: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 10.16K
mh02KK-134: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 9.59 K
mh09KK-020: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 8.39 K
mh21KK-320: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 8.00 K
mh16KK-302: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 7.73 K
mh18KK-293: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 7.48 K
mh17KK-105: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 7.38 K
mh15KK-067: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 7.21 K
mh15KK-095: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 6.91 K
mh01KK-205: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 6.58 K
mh21KK-315: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 6.13 K
mh01KK-002: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 6.00 K
mh17KK-052: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.70 K
mh05KK-123: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.67 K
mh17KK-014: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.59 K
mh16KK-053: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.47 K
mh09KK-157: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.43 K
mh04KK-013: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.23 K
mh03KK-150: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5.15 K
mh13KK-225: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.94 K
mh04KK-030: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.79 K
mh02KK-003: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.59 K
mh04KK-017: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.58 K
mh04KK-010: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.41 K
mh20KK-058: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.38 K
mh15KK-104: ▇▇▇▇▇▇▇▇▇▇▇▇▇ 3.86 K
mh11KK-040: ▇▇▇▇▇▇▇▇▇▇▇▇▇ 3.74 K
mh13KK-218: ▇▇▇▇▇▇▇▇▇▇▇▇ 3.62 K
mh09KK-152: ▇▇▇▇▇▇▇▇▇▇▇▇ 3.57 K
mh01KK-172: ▇▇▇▇▇▇▇▇▇▇▇▇ 3.51 K
mh22KK-061: ▇▇▇▇▇▇▇▇▇▇▇ 3.27 K
mh13KK-213: ▇▇▇▇▇▇▇▇▇▇▇ 3.23 K
mh05KK-124: ▇▇▇▇▇▇▇▇▇▇ 2.86 K
mh19KK-299: ▇▇▇▇▇▇▇▇▇ 2.80 K
mh13KK-217: ▇▇▇▇▇▇▇▇▇ 2.75 K
mh18KK-285: ▇▇▇▇▇▇▇▇▇ 2.63 K
mh12KK-202: ▇▇▇▇▇▇▇▇▇ 2.63 K
mh08KK-032: ▇▇▇▇▇▇▇▇▇ 2.55 K
mh05KK-122: ▇▇▇▇▇▇▇▇ 2.51 K
mh09KK-153: ▇▇▇▇▇▇▇▇ 2.49 K
mh09KK-033: ▇▇▇▇▇▇▇▇ 2.48 K
mh06KK-030: ▇▇▇▇▇▇▇▇ 2.45 K
mh17KK-272: ▇▇▇▇▇▇▇▇ 2.41 K
mh13KK-223: ▇▇▇▇▇▇▇▇ 2.38 K
mh05KK-062: ▇▇▇▇▇▇▇▇ 2.34 K
mh01KK-211: ▇▇▇▇▇▇▇▇ 2.31 K
mh11KK-036: ▇▇▇▇▇▇▇▇ 2.29 K
mh19KK-301: ▇▇▇▇▇▇▇▇ 2.28 K
mh20KK-307: ▇▇▇▇▇▇▇ 2.23 K
mh16KK-061: ▇▇▇▇▇▇▇ 2.21 K
mh02KK-105: ▇▇▇▇▇▇▇ 2.06 K
mh03KK-006: ▇▇▇▇▇▇ 1.95 K
mh01KK-001: ▇▇▇▇▇▇ 1.92 K
mh02KK-215: ▇▇▇▇▇ 1.68 K
mh21KK-316: ▇▇▇▇▇ 1.65 K
mh10KK-169: ▇▇▇▇▇ 1.54 K
mh16KK-049: ▇▇▇▇ 1.13 K
mh12KK-046: ▇▇▇ 884.00
mh22KK-069: ▇▇ 642.00
mh21KK-324: ▇▇ 581.00
mh11KK-180: ▇ 513.00
mh06KK-031: ▇ 505.00
mh02KK-201: ▇ 445.00
mh20KK-035: ▇ 395.00
mh02KK-136: ▇ 310.00
mh13KK-047: ▏ 256.00
mh10KK-170: ▏ 22.00

Extent of imbalance (chi-square statistic): 0.5841
```

![dewd2](https://user-images.githubusercontent.com/566823/161164141-6184c3cf-874b-4afa-ab3a-9c1b6ba0ec32.png)

Updated usage statement for `mhpl8r balance`.

```
$ mhpl8r balance -h
usage: mhpl8r balance [-h] [-c FILE] [-D] [-q] [--figure FILE] [--figsize W H] [--dpi DPI] [--color COL] input

Plot interlocus balance in the terminal and/or a high-resolution graphic. Also normalize read counts and perform
a chi-square goodness-of-fit test assuming uniform read coverage across markers. The reported chi-square
statistic measures the extent of imbalance, and can be compared among samples sequenced using the same panel:
the minimum value of 0 represents perfectly uniform coverage, while the maximum value of D occurs when all reads
map to a single marker (D represents the degrees of freedom, or the number of markers minus 1).

positional arguments:
  input                a typing result including haplotype counts in JSON format

optional arguments:
  -h, --help           show this help message and exit
  -c FILE, --csv FILE  write read counts to FILE in CSV format
  -D, --no-discarded   do not included mapping but discarded reads in read counts; by default, reads that are
                       mapped to the marker but discarded because they do not span all variants at the marker
                       are included
  -q, --quiet          do not print interlocus balance histogram to standard output in ASCII
  --figure FILE        plot interlocus balance histogram to FILE using Matplotlib; image format is inferred from
                       extension of provided file name
  --figsize W H        dimensions (width × height in inches) of the image file to be generated; 6 4 by default
  --dpi DPI            resolution (in dots per inch) of the image file to be generated; DPI=200 by default
  --color COL          color of the histogram to be generated in the image file; COL='#1f77b4' by default
```

And this is the updated API documentation.

<img width="830" alt="Screen Shot 2022-03-30 at 2 04 58 PM" src="https://user-images.githubusercontent.com/566823/160901873-ff9ab880-cbf2-40c8-8c2d-0699e1322726.png">

Partially addresses #119.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
