### PR TITLE
New typing_rate method for TypingResult class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - New API and CLI entry points for computing and visualizing heterozygote balance (#122).
+- New `typing_rate` method for the TypingResult class (#127).
 
 ### Changed
 - Interlocus balance code updated to support generating high-resolution graphics and performing a chi-square goodness-of-fit test (#121).

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -417,6 +417,27 @@ class TypingResult(Profile):
         table = pd.DataFrame(entries, columns=column_names)
         table.to_csv(outfile, index=False)
 
+    def typing_rate(self):
+        data = {
+            "Marker": list(),
+            "TypedReads": list(),
+            "TotalReads": list(),
+            "TypingRate": list(),
+        }
+        for marker, mdata in self.data["markers"].items():
+            num_typed_reads = 0
+            for mhallele, count in mdata["typing_result"].items():
+                num_typed_reads += count
+            total_reads = num_typed_reads + mdata["num_discarded_reads"]
+            rate = 0.0
+            if total_reads > 0:
+                rate = num_typed_reads / total_reads
+            data["Marker"].append(marker)
+            data["TypedReads"].append(num_typed_reads)
+            data["TotalReads"].append(total_reads)
+            data["TypingRate"].append(rate)
+        return pd.DataFrame(data)
+
     @property
     def gttype(self):
         return "TypingResult"

--- a/microhapulator/tests/test_profile.py
+++ b/microhapulator/tests/test_profile.py
@@ -112,3 +112,14 @@ def test_bed_error():
     markers = pd.read_csv(data_file("def/loc2-offsets.tsv"), sep="\t")
     with pytest.raises(ValueError, match=r"unknown marker identifier 'BOGUS'"):
         print(p.bedstr(markers))
+
+
+def test_typing_rate():
+    result = TypingResult(fromfile=data_file("prof/two-contrib-even.json"))
+    rates = result.typing_rate()
+    assert rates.TypedReads.head(5).to_list() == [3427, 2653, 3241, 4105, 3819]
+    assert rates.TotalReads.head(5).to_list() == [4550, 4540, 4539, 4531, 4538]
+    expected = [0.753187, 0.584361, 0.714034, 0.905981, 0.841560]
+    observed = rates.TypingRate.head(5).to_list()
+    for exp, obs in zip(expected, observed):
+        assert exp == pytest.approx(obs)


### PR DESCRIPTION
This PR implements a new `typing_rate` method for the TypingResult class. It returns a Pandas dataframe with counts of typed reads and total candidate typed reads (mapped reads) per marker. Related to #120.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
