### PR TITLE
Plot read length distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - New API and CLI entry points for computing and visualizing heterozygote balance (#122).
+- New API function for plotting distribution of read lengths (#128).
 
 ### Changed
 - Interlocus balance code updated to support generating high-resolution graphics and performing a chi-square goodness-of-fit test (#121).

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,10 @@ In brief, this means that every stable version of the MicroHapulator software is
 ## Analysis, QA/QC, and interpretation
 
 ```{eval-rst}
+.. autofunction:: microhapulator.api.read_length_dist
+```
+
+```{eval-rst}
 .. autofunction:: microhapulator.api.interlocus_balance
 ```
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -561,7 +561,14 @@ def type(bamfile, markertsv, minbasequal=10, max_depth=1e6):
     return result
 
 
-def read_length_dist(fastq, outfile, scale=1e-3, title=None):
+def read_length_dist(fastq, outfile, scale=1000, title=None):
+    """Plot distribution of read lengths
+
+    :param str fastq: path of a FASTQ file containing NGS reads
+    :param str outfile: path of a graphic file to create
+    :param float scale: scaling factor for the Y axis
+    :param str title: title for the plot
+    """
     backend = matplotlib.get_backend()
     plt.switch_backend("Agg")
     lengths = list()
@@ -569,7 +576,7 @@ def read_length_dist(fastq, outfile, scale=1e-3, title=None):
         for record in SeqIO.parse(fh, "fastq"):
             lengths.append(len(record))
     fig = plt.figure(figsize=(6, 4), dpi=200)
-    plt.hist(lengths, bins=25, weights=[scale] * len(lengths), edgecolor="#000099")
+    plt.hist(lengths, bins=25, weights=[1 / scale] * len(lengths), edgecolor="#000099")
     plt.xlim(0, 500)
     ax = plt.gca()
     ax.yaxis.grid(True, color="#DDDDDD")
@@ -580,7 +587,7 @@ def read_length_dist(fastq, outfile, scale=1e-3, title=None):
     ax.spines["bottom"].set_color("#CCCCCC")
     ax.tick_params(left=False)
     ax.set_xlabel("Length of Merged Read Pair (bp)", labelpad=15, fontsize=16)
-    ax.set_ylabel("Frequency (× 1000)", labelpad=15, fontsize=16)
+    ax.set_ylabel(f"Frequency (× {scale})", labelpad=15, fontsize=16)
     if title:
         ax.set_title(title, pad=25, fontsize=18)
     plt.savefig(outfile, bbox_inches="tight")

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -11,8 +11,10 @@
 # -------------------------------------------------------------------------------------------------
 
 
+from Bio import SeqIO
 from collections import namedtuple, defaultdict
 from math import ceil
+import matplotlib
 from matplotlib import pyplot as plt
 from microhapulator.parsers import load_marker_definitions, cross_check_marker_ids
 from microhapulator.profile import SimulatedProfile, TypingResult
@@ -557,3 +559,29 @@ def type(bamfile, markertsv, minbasequal=10, max_depth=1e6):
         for haplotype, count in htcounts.items():
             result.record_haplotype(locusid, haplotype, count)
     return result
+
+
+def read_length_dist(fastq, outfile, scale=1e-3, title=None):
+    backend = matplotlib.get_backend()
+    plt.switch_backend("Agg")
+    lengths = list()
+    with open(fastq, "r") as fh:
+        for record in SeqIO.parse(fh, "fastq"):
+            lengths.append(len(record))
+    fig = plt.figure(figsize=(6, 4), dpi=200)
+    plt.hist(lengths, bins=25, weights=[scale] * len(lengths), edgecolor="#000099")
+    plt.xlim(0, 500)
+    ax = plt.gca()
+    ax.yaxis.grid(True, color="#DDDDDD")
+    ax.set_axisbelow(True)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_visible(False)
+    ax.spines["bottom"].set_color("#CCCCCC")
+    ax.tick_params(left=False)
+    ax.set_xlabel("Length of Merged Read Pair (bp)", labelpad=15, fontsize=16)
+    ax.set_ylabel("Frequency (× 1000)", labelpad=15, fontsize=16)
+    if title:
+        ax.set_title(title, pad=25, fontsize=18)
+    plt.savefig(outfile, bbox_inches="tight")
+    plt.switch_backend(backend)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
+        "biopython",
         "happer>=0.1",
         "insilicoseq>=1.5.2",
         "jsonschema>=4.0",


### PR DESCRIPTION
This PR adds a new API function for plotting input read length distribution. We'll likely want to do this in the near future for unmerged paired reads, but for not it only works for merged/single-end reads. See #125.

**NOTE**: The feature has been tested manually but there is no straightforward way to integrate into the test suite, so punting on that.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- ~~Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)~~
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
