### PR TITLE
Add `mhpl8r getrefr` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 microhapulator/tests/data/bam/sandawe-dad.bam.bai
 docs/_build/
 build/
+microhapulator/data/hg38.fasta.gz*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New API and CLI entry points for computing and visualizing heterozygote balance (#122).
 - New `typing_rate` method for the TypingResult class (#127).
 - New API function for plotting distribution of read lengths (#128).
+- New CLI entry point for downloading GRCh38 (#130).
 
 ### Changed
 - Interlocus balance code updated to support generating high-resolution graphics and performing a chi-square goodness-of-fit test (#121).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,6 +112,16 @@ In brief, this means that every stable version of the MicroHapulator software is
 :nodefault:
 ```
 
+### `mhpl8r getrefr`
+
+```{argparse}
+:module: microhapulator.cli
+:func: get_parser
+:prog: mhpl8r
+:path: getrefr
+:nodefault:
+```
+
 
 ## Simulation
 

--- a/microhapulator/cli/__init__.py
+++ b/microhapulator/cli/__init__.py
@@ -19,6 +19,7 @@ from . import convert
 from . import diff
 from . import dist
 from . import filter
+from . import getrefr
 from . import hetbalance
 from . import locbalance
 from . import mix
@@ -36,6 +37,7 @@ mains = {
     "diff": diff.main,
     "dist": dist.main,
     "filter": filter.main,
+    "getrefr": getrefr.main,
     "hetbalance": hetbalance.main,
     "locbalance": locbalance.main,
     "mix": mix.main,
@@ -53,6 +55,7 @@ subparser_funcs = {
     "diff": diff.subparser,
     "dist": dist.subparser,
     "filter": filter.subparser,
+    "getrefr": getrefr.subparser,
     "hetbalance": hetbalance.subparser,
     "locbalance": locbalance.subparser,
     "mix": mix.subparser,

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -59,8 +59,9 @@ def subparser(subparsers):
 
 def main(args):
     url = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz"
+    checksum = "70fb7af4dff26bffdf27dbef80caf1f0359d488f"
     hg38path = Path(resource_filename("microhapulator", "data/hg38.fasta.gz"))
-    if download_is_needed(url, hg38path, "70fb7af4dff26bffdf27dbef80caf1f0359d488f"):
+    if download_is_needed(url, hg38path, checksum):
         print("[MicroHapulator] downloading GRCh38 reference genome", file=sys.stderr)
         with ProgressBar(unit="B", unit_scale=True, miniters=1, desc=hg38path.name) as pb:
             urlretrieve(url, hg38path, reporthook=pb.update_to)
@@ -69,7 +70,7 @@ def main(args):
             f"[MicroHapulator] file {str(hg38path)} already present, skipping download",
             file=sys.stderr,
         )
-    if compute_shasum(hg38path) != "70fb7af4dff26bffdf27dbef80caf1f0359d488f":
+    if compute_shasum(hg38path) != checksum:
         raise ValueError(f"checksum failed for {str(hg38path)}")
     index_present = True
     for suffix in ("amb", "ann", "bwt", "pac", "sa"):

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -1,0 +1,84 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2022, DHS.
+#
+# This file is part of MicroHapulator (https://github.com/bioforensics/microhapulator) and is
+# licensed under the BSD license: see LICENSE.txt.
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+
+from hashlib import sha1
+from pathlib import Path
+from pkg_resources import resource_filename
+from subprocess import run
+import sys
+from tqdm import tqdm
+from urllib.request import urlretrieve
+
+
+class ProgressBar(tqdm):
+    """Stolen shamelessly from https://stackoverflow.com/a/53877507/459780."""
+
+    def update_to(self, b=1, bsize=1, tsize=None):
+        if tsize is not None:
+            self.total = tsize
+        self.update(b * bsize - self.n)
+
+
+def compute_shasum(filename):
+    with open(filename, "rb") as fh:
+        shahash = sha1()
+        for block in iter(lambda: fh.read(4096), b""):
+            shahash.update(block)
+        return shahash.hexdigest()
+
+
+def download_is_needed(url, filepath, checksum):
+    if filepath.exists():
+        if not filepath.is_file():
+            raise FileNotFoundError(f"{str(filepath)} does not exist or is not a normal file")
+        shasum = compute_shasum(filepath)
+        if shasum != checksum:
+            print(
+                f"[MicroHapulator] file {str(filepath)} already present, but checksum failed; re-downloading",
+                file=sys.stderr,
+            )
+        return shasum != checksum
+    else:
+        return True
+
+
+def subparser(subparsers):
+    desc = "Download and index a GRCh38 assembly file suitable as a whole-genome mapping reference"
+    cli = subparsers.add_parser("getrefr", description=desc)
+
+
+def main(args):
+    url = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz"
+    hg38path = Path(resource_filename("microhapulator", "data/hg38.fasta.gz"))
+    if download_is_needed(url, hg38path, "70fb7af4dff26bffdf27dbef80caf1f0359d488f"):
+        print("[MicroHapulator] downloading GRCh38 reference genome", file=sys.stderr)
+        with ProgressBar(unit="B", unit_scale=True, miniters=1, desc=hg38path.name) as pb:
+            urlretrieve(url, hg38path, reporthook=pb.update_to)
+    else:
+        print(
+            f"[MicroHapulator] file {str(hg38path)} already present, skipping download",
+            file=sys.stderr,
+        )
+    if compute_shasum(hg38path) != "70fb7af4dff26bffdf27dbef80caf1f0359d488f":
+        raise ValueError(f"checksum failed for {str(hg38path)}")
+    index_present = True
+    for suffix in ("amb", "ann", "bwt", "pac", "sa"):
+        idxfile = Path(f"{str(hg38path)}.{suffix}")
+        if not idxfile.is_file():
+            index_present = False
+            break
+    if index_present:
+        print(f"[MicroHapulator] BWA index present, good to go!", file=sys.stderr)
+    else:
+        print(f"[MicroHapulator] building BWA index, this will take some time...", file=sys.stderr)
+        run(["bwa", "index", str(hg38path)], check=True)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "pandas>1.0",
         "scipy>=1.7",
         "termgraph>=0.5",
+        "tqdm>=4.0",
     ],
     entry_points={"console_scripts": ["mhpl8r = microhapulator.cli:main"]},
     classifiers=[


### PR DESCRIPTION
New command line entry point for downloading a copy of the GRCh38 assembly suitable for whole-genome mapping. Closes #124.

**NOTE**: This was tested manually, but testing cannot be easily integrated into the test suite.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- ~~Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)~~
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
