### PR TITLE
Tweak plots

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,6 @@
 
 - [ ] Changes are clearly described above
 - [ ] Any relevant issue threads are referenced in the description
-- [ ] Any new features are tested (see [docs/DEVEL.md](docs/DEVEL.md) for details)
+- [ ] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
+- [ ] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
 - [ ] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 microhapulator/tests/data/bam/sandawe-dad.bam.bai
 docs/_build/
 build/
+.vscode/

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -57,9 +57,9 @@ def interlocus_balance(
     include_discarded=True,
     terminal=True,
     tofile=None,
+    title=None,
     figsize=(6, 4),
     dpi=200,
-    color="#1f77b4",
 ):
     """Compute interlocus balance
 
@@ -76,7 +76,6 @@ def interlocus_balance(
     :param str tofile: name of image file to which the interlocus balance histogram will be written using Matplotlib; image format is inferred from file extension; by default, no image file is generated
     :param tuple figsize: a 2-tuple of integers indicating the dimensions of the image file to be generated
     :param int dpi: resolution (in dots per inch) of the image file to be generated
-    :param str color: color of the histogram to be generated in the image file
     :return: a tuple (S, C) where S is the chi-square statistic, and C is a table of total read counts for each marker
     :rtype: tuple(float, pandas.DataFrame)
     """
@@ -89,16 +88,18 @@ def interlocus_balance(
             data.to_csv(tfile, index=False, header=False)
             run(["termgraph", tfile])
     if tofile:
+        backend = matplotlib.get_backend()
+        plt.switch_backend("Agg")
         plt.figure(figsize=figsize, dpi=dpi)
         x = range(len(data))
         y = [c / 1000 for c in data.ReadCount]
-        plt.bar(x, y, color=color)
+        plt.bar(x, y)
         plt.xticks([])
-        plt.xlabel("Marker")
+        plt.xlabel("Marker", labelpad=15, fontsize=16)
         if include_discarded:
-            plt.ylabel("Reads Mapped (× 1000)")
+            plt.ylabel("Reads Mapped (× 1000)", labelpad=15, fontsize=16)
         else:
-            plt.ylabel("Reads Mapped and Typed (× 1000)")
+            plt.ylabel("Reads Mapped and Typed (× 1000)", labelpad=15, fontsize=16)
         ax = plt.gca()
         ax.yaxis.grid(True, color="#DDDDDD")
         ax.set_axisbelow(True)
@@ -107,8 +108,10 @@ def interlocus_balance(
         ax.spines["left"].set_visible(False)
         ax.spines["bottom"].set_color("#CCCCCC")
         ax.tick_params(left=False)
-        plt.title("Interlocus Balance")
-        plt.savefig(tofile)
+        if title is not None:
+            plt.title(title, pad=25, fontsize=18)
+        plt.savefig(tofile, bbox_inches="tight")
+        plt.switch_backend(backend)
     return chisq, data
 
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -148,7 +148,7 @@ def genotype_counts(profile):
 
 
 def heterozygote_balance(
-    result, tofile=None, figsize=None, dpi=200, dolabels=False, absolute=False
+    result, tofile=None, title=None, figsize=None, dpi=200, dolabels=False, absolute=False
 ):
     """Compute heterozygote balance
 
@@ -171,6 +171,8 @@ def heterozygote_balance(
     data = genotype_counts(result)
     tstat, pval = ttest_rel(data.Allele1Perc, data.Allele2Perc, alternative="greater")
     if tofile:
+        backend = matplotlib.get_backend()
+        plt.switch_backend("Agg")
         if figsize is None:
             width = len(data) / 2 if dolabels else len(data) / 4
             width = max(8, width)
@@ -204,13 +206,15 @@ def heterozygote_balance(
         ax.tick_params(bottom=False, left=False)
         ax.set_xlabel("Marker", labelpad=15, fontsize=16)
         ax.set_ylabel(ylabel, labelpad=15, fontsize=16)
-        ax.set_title("Heterozygote Balance", pad=25, fontsize=18)
+        if title is not None:
+            ax.set_title(title, pad=25, fontsize=18)
         if dolabels:
             counts = data.Allele1Count + data.Allele2Count
             for m, height, count in zip(x, y1, counts):
                 ax.text(m, height + 0.01, f"{count:,}", ha="center", va="bottom", rotation=90)
         ax.legend(["Major Allele", "Minor Allele"], loc="lower left")
         plt.savefig(tofile, bbox_inches="tight")
+        plt.switch_backend(backend)
     return tstat, data
 
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -74,6 +74,7 @@ def interlocus_balance(
     :param bool included_discarded: flag indicating whether to include in each marker's total read count reads that are successfully aligned but discarded because they do not span all SNPs at the marker
     :param bool terminal: flag indicating whether to print the interlocus balance histogram to standard output; enabled by default
     :param str tofile: name of image file to which the interlocus balance histogram will be written using Matplotlib; image format is inferred from file extension; by default, no image file is generated
+    :param str title: add a title (such as a sample name) to the histogram plot
     :param tuple figsize: a 2-tuple of integers indicating the dimensions of the image file to be generated
     :param int dpi: resolution (in dots per inch) of the image file to be generated
     :return: a tuple (S, C) where S is the chi-square statistic, and C is a table of total read counts for each marker
@@ -161,6 +162,7 @@ def heterozygote_balance(
 
     :param microhapulator.profile.TypingResult result: a filtered typing result including haplotype counts and genotype calls
     :param str tofile: name of image file to which the interlocus balance histogram will be written using Matplotlib; image format is inferred from file extension; by default, no image file is generated
+    :param str title: add a title (such as a sample name) to the histogram plot
     :param tuple figsize: a 2-tuple of integers indicating the dimensions of the image file to be generated
     :param int dpi: resolution (in dots per inch) of the image file to be generated
     :param bool dolabels: flag indicating whether marker labels and read counts should be added to the figure

--- a/microhapulator/cli/hetbalance.py
+++ b/microhapulator/cli/hetbalance.py
@@ -41,6 +41,13 @@ def subparser(subparsers):
         help="resolution (in dots per inch) of the image file to be generated; DPI=200 by default",
     )
     cli.add_argument(
+        "-t",
+        "--title",
+        metavar="T",
+        default=None,
+        help="add a title (such as a sample name) to the histogram plot",
+    )
+    cli.add_argument(
         "--labels", action="store_true", help="include labels showing marker names and read counts"
     )
     cli.add_argument(
@@ -54,6 +61,7 @@ def main(args):
     tstat, data = mhapi.heterozygote_balance(
         result,
         tofile=args.figure,
+        title=args.title,
         figsize=args.figsize,
         dpi=args.dpi,
         dolabels=args.labels,

--- a/microhapulator/cli/locbalance.py
+++ b/microhapulator/cli/locbalance.py
@@ -64,10 +64,11 @@ def subparser(subparsers):
         help="resolution (in dots per inch) of the image file to be generated; DPI=200 by default",
     )
     cli.add_argument(
-        "--color",
-        metavar="COL",
-        default="#1f77b4",
-        help="color of the histogram to be generated in the image file; COL='#1f77b4' by default",
+        "-t",
+        "--title",
+        metavar="T",
+        default=None,
+        help="add a title (such as a sample name) to the histogram plot",
     )
     cli.add_argument("input", help="a typing result including haplotype counts in JSON format")
 
@@ -79,9 +80,9 @@ def main(args):
         include_discarded=args.discarded,
         terminal=not args.quiet,
         tofile=args.figure,
+        title=args.title,
         figsize=args.figsize,
         dpi=args.dpi,
-        color=args.color,
     )
     print(f"Extent of imbalance (chi-square statistic): {chisq:.4f}")
     if args.csv:

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -100,7 +100,7 @@ class Profile(object):
             )
         return set([a["haplotype"] for a in self.data["markers"][markerid]["genotype"]])
 
-    def rand_match_prob(self, freqs):
+    def rand_match_prob(self, freqs, minfreq=0.01):
         """Compute the random match probability of this profile.
 
         Given a set of population allele frequencies, the random match
@@ -117,14 +117,14 @@ class Profile(object):
                 raise RandomMatchError(msg)
             result = freqs[(freqs.Marker == marker) & (freqs.Haplotype.isin(haplotypes))]
             if len(haplotypes) == 1:
-                p = 0.001
+                p = minfreq
                 if len(result) == 1:
                     pp = list(result.Frequency)[0]
                     if pp > 0.0:
                         p = pp
                 prob *= p * p
             else:
-                p, q = 0.001, 0.001
+                p, q = minfreq, minfreq
                 if len(result) == 2:
                     pp, qp = list(result.Frequency)
                 elif len(result) == 1:

--- a/microhapulator/tests/test_prob.py
+++ b/microhapulator/tests/test_prob.py
@@ -74,9 +74,9 @@ def test_prob_cli_lrt(capsys):
 
 def test_prob_zero_freq(k5freqs):
     p = Profile(fromfile=data_file("prof/korea-5loc-zerofreq.json"))
-    assert p.rand_match_prob(k5freqs) == pytest.approx(2.3708e-11)
+    assert p.rand_match_prob(k5freqs) == pytest.approx(2.3708e-10)
 
 
 def test_prob_missing_freq(k5freqs):
     p = Profile(fromfile=data_file("prof/korea-5loc-missfreq.json"))
-    assert p.rand_match_prob(k5freqs) == pytest.approx(7.8360e-10)
+    assert p.rand_match_prob(k5freqs) == pytest.approx(7.8360e-9)


### PR DESCRIPTION
This PR makes some changes to the heterozygote balance and interlocus balance plots created by MicroHapulator, with an eye for the report generated at the end of a full analysis pipeline (#120).

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- ~~Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)~~
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
