### PR TITLE
Draft: expose threshold parameters, produce interoperable profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- Profiles compatible with probgen programs now included in pipe output (#135).
+
+### Changed
+- Exposed static and dynamic threshold configuration to pipe CLI (#135).
+
+
 ## [0.6.1] 2022-04-27
 
 ### Fixed

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -23,6 +23,7 @@ rule report:
     input:
         "analysis/summary.tsv",
         expand("analysis/{sample}/{sample}-type.json", sample=config["samples"]),
+        expand("analysis/{sample}/profiles/{sample}-{suffix}.csv", sample=config["samples"], suffix=("qual", "quant", "qual-ref", "quant-ref")),
         expand("analysis/{sample}/{sample}-r1-read-lengths.png", sample=config["samples"]),
         expand("analysis/{sample}/{sample}-r2-read-lengths.png", sample=config["samples"]),
         expand("analysis/{sample}/{sample}-merged-read-lengths.png", sample=config["samples"]),
@@ -173,8 +174,29 @@ rule apply_filters:
         json=rules.call_haplotypes.output.typing_result,
     output:
         genotype_call="analysis/{sample}/{sample}-type.json",
+    params:
+        staticthresh="" if config["thresh_static"] is None else f"--static {config['thresh_static']}",
+        dynamicthresh="" if config["thresh_dynamic"] is None else f"--dynamic {config['thresh_dynamic']}",
+        threshfile="" if config["thresh_file"] is None else f"--config {config['thresh_file']}",
     shell:
-        "mhpl8r filter {input} --out {output} --static 5 --dynamic 0.02"
+        "mhpl8r filter {input} --out {output} {params.staticthresh} {params.dynamicthresh} {params.threshfile}"
+
+
+rule profile_convert:
+    input:
+        json=rules.apply_filters.output.genotype_call,
+    output:
+        qual="analysis/{sample}/profiles/{sample}-qual.csv",
+        quant="analysis/{sample}/profiles/{sample}-quant.csv",
+        qualref="analysis/{sample}/profiles/{sample}-qual-ref.csv",
+        quantref="analysis/{sample}/profiles/{sample}-quant-ref.csv",
+    shell:
+        """
+        mhpl8r convert {input} {wildcards.sample} --out {output[0]} --no-counts
+        mhpl8r convert {input} {wildcards.sample} --out {output[1]}
+        mhpl8r convert {input} {wildcards.sample} --out {output[2]} --no-counts --fix-homo
+        mhpl8r convert {input} {wildcards.sample} --out {output[3]} --fix-homo
+        """
 
 
 rule interlocus_balance:

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -23,7 +23,11 @@ rule report:
     input:
         "analysis/summary.tsv",
         expand("analysis/{sample}/{sample}-type.json", sample=config["samples"]),
-        expand("analysis/{sample}/profiles/{sample}-{suffix}.csv", sample=config["samples"], suffix=("qual", "quant", "qual-ref", "quant-ref")),
+        expand(
+            "analysis/{sample}/profiles/{sample}-{suffix}.csv",
+            sample=config["samples"],
+            suffix=("qual", "quant", "qual-ref", "quant-ref"),
+        ),
         expand("analysis/{sample}/{sample}-r1-read-lengths.png", sample=config["samples"]),
         expand("analysis/{sample}/{sample}-r2-read-lengths.png", sample=config["samples"]),
         expand("analysis/{sample}/{sample}-merged-read-lengths.png", sample=config["samples"]),
@@ -175,8 +179,12 @@ rule apply_filters:
     output:
         genotype_call="analysis/{sample}/{sample}-type.json",
     params:
-        staticthresh="" if config["thresh_static"] is None else f"--static {config['thresh_static']}",
-        dynamicthresh="" if config["thresh_dynamic"] is None else f"--dynamic {config['thresh_dynamic']}",
+        staticthresh=""
+        if config["thresh_static"] is None
+        else f"--static {config['thresh_static']}",
+        dynamicthresh=""
+        if config["thresh_dynamic"] is None
+        else f"--dynamic {config['thresh_dynamic']}",
         threshfile="" if config["thresh_file"] is None else f"--config {config['thresh_file']}",
     shell:
         "mhpl8r filter {input} --out {output} {params.staticthresh} {params.dynamicthresh} {params.threshfile}"

--- a/microhapulator/cli/filter.py
+++ b/microhapulator/cli/filter.py
@@ -41,12 +41,12 @@ def subparser(subparsers):
         metavar="DT",
         type=float,
         default=None,
-        help=r"global percentage of total read count; e.g. use --dynamic=0.02 to apply a 2%% analytical threshold",
+        help="global percentage of total read count threshold; e.g. use --dynamic=0.02 to apply a 2%% analytical threshold",
     )
     cli.add_argument(
         "-c",
         "--config",
-        metavar="FILE",
+        metavar="CSV",
         default=None,
         help="CSV file specifying marker-specific thresholds to override global thresholds; three required columns: 'Marker' for the marker name; 'Static' and 'Dynamic' for marker-specific thresholds",
     )

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -132,6 +132,29 @@ def subparser(subparsers):
         help="process each batch using T threads; by default, one thread per available core is used",
     )
     cli.add_argument(
+        "-s",
+        "--static",
+        metavar="ST",
+        type=int,
+        default=None,
+        help="global fixed read count threshold",
+    )
+    cli.add_argument(
+        "-d",
+        "--dynamic",
+        metavar="DT",
+        type=float,
+        default=None,
+        help="global percentage of total read count threshold; e.g. use --dynamic=0.02 to apply a 2%% analytical threshold",
+    )
+    cli.add_argument(
+        "-c",
+        "--config",
+        metavar="CSV",
+        default=None,
+        help="CSV file specifying marker-specific thresholds to override global thresholds; three required columns: 'Marker' for the marker name; 'Static' and 'Dynamic' for marker-specific thresholds",
+    )
+    cli.add_argument(
         "--copy-input",
         action="store_true",
         help="copy input files to working directory; by default, input files are symlinked",
@@ -173,6 +196,9 @@ def main(args):
         mhrefr=Path(args.markerrefr).resolve(),
         mhdefn=Path(args.markerdefn).resolve(),
         hg38path=Path(args.hg38).resolve(),
+        thresh_static=args.static,
+        thresh_dynamic=args.dynamic,
+        thresh_file=args.config,
     )
     snakefile = resource_filename("microhapulator", "Snakefile")
     success = snakemake(

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -415,7 +415,7 @@ class TypingResult(Profile):
             entry = [samplename, marker, *haplotypes, *hapcounts]
             entries.append(entry)
         table = pd.DataFrame(entries, columns=column_names)
-        table.to_csv(outfile, index=False)
+        table.to_csv(outfile, index=False, float_format="%d")
 
     def typing_rate(self):
         data = {

--- a/microhapulator/tests/data/gbr-usc-profile.csv
+++ b/microhapulator/tests/data/gbr-usc-profile.csv
@@ -1,0 +1,11 @@
+SampleName,Marker,Allele1,Allele2,Height1,Height2
+gbr-usc,mh01USC-1pA,"A,T,G,C",,486,
+gbr-usc,mh02USC-2pA,"T,A,A,T","T,C,G,A",242,242
+gbr-usc,mh03USC-3pA,"A,C,G,T","C,C,G,T",242,243
+gbr-usc,mh04USC-4pA,"C,T,C,A","G,G,C,A",242,244
+gbr-usc,mh05USC-5pA,"A,C,A,G","A,C,T,G",242,242
+gbr-usc,mh06USC-6pA,"C,C,A","G,C,T",240,245
+gbr-usc,mh07USC-7pA,"A,G,T,C",,482,
+gbr-usc,mh08USC-8pA,"A,G,T,G","G,G,T,A",245,245
+gbr-usc,mh09USC-9pA,"A,T,C,A,A","G,T,C,A,C",243,245
+gbr-usc,mh10USC-10pA,"A,G,G","T,G,G",245,244

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -65,3 +65,8 @@ def test_pipe_gbr_usc10(tmp_path):
     expected = pd.read_csv(data_file("gbr-usc-summary.tsv"), sep="\t")
     observed = pd.read_csv(tmp_path / "analysis" / "summary.tsv", sep="\t")
     assert observed.equals(expected)
+    profile = tmp_path / "analysis" / "gbr-usc" / "profiles" / "gbr-usc-quant.csv"
+    assert profile.is_file()
+    expected = pd.read_csv(data_file("gbr-usc-profile.csv"))
+    observed = pd.read_csv(profile)
+    assert observed.equals(expected)

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -49,8 +49,9 @@ def test_pipe_gbr_usc10(tmp_path):
         "gbr-usc",
         "--workdir",
         str(tmp_path),
-        "--threads",
-        "1",
+        "--threads=1",
+        "--static=5",
+        "--dynamic=0.02",
         "--hg38",
         hg38,
     ]


### PR DESCRIPTION
Currently, a static threshold of 5 reads and a dynamic threshold of 2% is hard-coded into the MicroHapulator end-to-end workflow as placeholders. This PR exposes these parameters to the CLI so that the user can configure them with global and per-marker thresholds.

Also, this PR adds a new rule the converts profiles into CSV formats that are compatible with popular probgen programs—important functionality that has been advertised but not yet implemented.

----------

- [x] Changes are clearly described above
- ~~Any relevant issue threads are referenced in the description~~
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
