### PR TITLE
Haplotype call plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Profiles compatible with probgen programs now included in pipe output (#135).
+- Haplotype call plots now included in the HTML report (#136).
 
 ### Changed
 - Exposed static and dynamic threshold configuration to pipe CLI (#135).

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,10 @@ In brief, this means that every stable version of the MicroHapulator software is
 ```
 
 ```{eval-rst}
+.. autofunction:: microhapulator.api.plot_haplotype_calls
+```
+
+```{eval-rst}
 .. autofunction:: microhapulator.api.heterozygote_balance
 ```
 

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -34,6 +34,7 @@ rule report:
         expand("analysis/{sample}/{sample}-interlocus-balance.png", sample=config["samples"]),
         expand("analysis/{sample}/{sample}-heterozygote-balance.png", sample=config["samples"]),
         expand("analysis/{sample}/fastqc/R{end}-fastqc.html", sample=config["samples"], end=(1, 2)),
+        expand("analysis/{sample}/callplots/.done", sample=config["samples"]),
         resource_filename("microhapulator", "data/template.html"),
     output:
         "report.html",
@@ -233,6 +234,18 @@ rule heterozygote_balance:
         mhpl8r hetbalance {input} --csv {output.counts} --figure {output.plot} --title {wildcards.sample} --labels \
             | tee {output.log}
         """
+
+
+rule plot_haplotype_calls:
+    input:
+        result=rules.apply_filters.output.genotype_call,
+    output:
+        sentinel=touch("analysis/{sample}/callplots/.done"),
+    run:
+        result = TypingResult(fromfile=input.result)
+        mhapi.plot_haplotype_calls(
+            result, f"analysis/{wildcards.sample}/callplots", sample=wildcards.sample
+        )
 
 
 rule download_full_reference:

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -181,12 +181,14 @@ rule apply_filters:
         genotype_call="analysis/{sample}/{sample}-type.json",
     params:
         staticthresh=""
-        if config["thresh_static"] is None
+        if config["thresh_static"] in (None, "None")
         else f"--static {config['thresh_static']}",
         dynamicthresh=""
-        if config["thresh_dynamic"] is None
+        if config["thresh_dynamic"] in (None, "None")
         else f"--dynamic {config['thresh_dynamic']}",
-        threshfile="" if config["thresh_file"] is None else f"--config {config['thresh_file']}",
+        threshfile=""
+        if config["thresh_file"] in (None, "None")
+        else f"--config {config['thresh_file']}",
     shell:
         "mhpl8r filter {input} --out {output} {params.staticthresh} {params.dynamicthresh} {params.threshfile}"
 

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -180,17 +180,11 @@ rule apply_filters:
     output:
         genotype_call="analysis/{sample}/{sample}-type.json",
     params:
-        staticthresh=""
-        if config["thresh_static"] in (None, "None")
-        else f"--static {config['thresh_static']}",
-        dynamicthresh=""
-        if config["thresh_dynamic"] in (None, "None")
-        else f"--dynamic {config['thresh_dynamic']}",
-        threshfile=""
-        if config["thresh_file"] in (None, "None")
-        else f"--config {config['thresh_file']}",
+        static="" if config["thresh_static"] == "" else f"--static {config['thresh_static']}",
+        dynamic="" if config["thresh_dynamic"] == "" else f"--dynamic {config['thresh_dynamic']}",
+        threshfile="" if config["thresh_file"] == "" else f"--config {config['thresh_file']}",
     shell:
-        "mhpl8r filter {input} --out {output} {params.staticthresh} {params.dynamicthresh} {params.threshfile}"
+        "mhpl8r filter {input} --out {output} {params.static} {params.dynamic} {params.threshfile}"
 
 
 rule profile_convert:

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -625,7 +625,7 @@ def plot_haplotype_calls(result, outdir, sample=None, plot_marker_name=True, ign
     for marker in result.markers():
         count_dict = result.allele_counts(marker)
         mdata = result.data["markers"][marker]
-        if "thresholds" in mdata and "static" in mdata["thresholds"]:
+        if ignore_low and "thresholds" in mdata and "static" in mdata["thresholds"]:
             static = mdata["thresholds"]["static"]
             count_dict = {allele: count for allele, count in count_dict.items() if count >= static}
         counts = count_dict.values()

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -131,27 +131,31 @@ def subparser(subparsers):
         default=cpu_count(),
         help="process each batch using T threads; by default, one thread per available core is used",
     )
+    # Normally the defaults for the next three arguments would be `None`. But the values are passed
+    # to Snakemake, which intermittently casts NoneTypes as a string, causing issues with the
+    # downstream code; e.g., attempts to open a non-existent `None` file. The empty string defaults
+    # and the lambda functions for data types are a workaround.
     cli.add_argument(
         "-s",
         "--static",
         metavar="ST",
-        type=int,
-        default=None,
+        type=lambda a: "" if a == "" else int(a),
+        default="",
         help="global fixed read count threshold",
     )
     cli.add_argument(
         "-d",
         "--dynamic",
         metavar="DT",
-        type=float,
-        default=None,
+        type=lambda a: "" if a == "" else float(a),
+        default="",
         help="global percentage of total read count threshold; e.g. use --dynamic=0.02 to apply a 2%% analytical threshold",
     )
     cli.add_argument(
         "-c",
         "--config",
         metavar="CSV",
-        default=None,
+        default="",
         help="CSV file specifying marker-specific thresholds to override global thresholds; three required columns: 'Marker' for the marker name; 'Static' and 'Dynamic' for marker-specific thresholds",
     )
     cli.add_argument(

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -146,6 +146,7 @@
             <a name="filters"></a>
             <h2>Genotype Calling</h2>
             <p>Fixed detection thresholds and dynamic analytical thresholds are applied to the typing result using <code>mhpl8r filter</code> to discriminate true and erroneous haplotypes and predict each sample's genotype. MicroHapulator applied a static filter of <strong>≥{{static}} reads</strong> as a detection threshold and a dynamic filter of <strong>≥{{"{:.1f}".format(dynamic*100)}}% of total reads</strong>.</p>
+            <p>Plots of the genotype calls, including the thresholds used to distinguish true haplotypes from false haplotypes, are available in each <code>analysis/{samplename}/callplots/</code> subdirectory, one graphics file per marker.</p>
 
             <p>The following figures show the heterozygote balance for each sample.
             {% for plot in plots["hetbalance"] %}

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -372,7 +372,7 @@ class TypingResult(Profile):
             totalcount = sum(hapcounts.values())
             filteredcount = 0
             if markerstatic is not None and markerstatic > 0:
-                self.data["markers"][marker]["thresholds"]["static"] = markerstatic
+                self.data["markers"][marker]["thresholds"]["static"] = int(markerstatic)
                 for haplotype, count in hapcounts.items():
                     if count < markerstatic:
                         filtered.add(haplotype)

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -27,6 +27,10 @@ import sys
 SCHEMA = None
 
 
+class RandomMatchError(ValueError):
+    pass
+
+
 def load_schema():
     with mhopen(package_file("data/profile-schema.json"), "r") as fh:
         return json.load(fh)

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -365,27 +365,35 @@ class TypingResult(Profile):
             if markerstatic is None and markerdynamic is None:
                 # No thresholds for calling haplotypes, just report raw haplotype counts
                 continue
+            self.data["markers"][marker]["thresholds"] = dict()
             hapcounts = mdata["typing_result"]
             genotype_call = set()
             filtered = set()
             totalcount = sum(hapcounts.values())
             filteredcount = 0
             if markerstatic is not None and markerstatic > 0:
+                self.data["markers"][marker]["thresholds"]["static"] = markerstatic
                 for haplotype, count in hapcounts.items():
                     if count < markerstatic:
                         filtered.add(haplotype)
                         filteredcount += count
             if markerdynamic is not None and markerdynamic > 0.0:
+                threshold = (totalcount - filteredcount) * markerdynamic
+                self.data["markers"][marker]["thresholds"]["dynamic"] = threshold
                 for haplotype, count in hapcounts.items():
-                    if haplotype in filtered:
-                        continue
-                    if count < (totalcount - filteredcount) * markerdynamic:
+                    if count < threshold:
                         filtered.add(haplotype)
-                    else:
-                        genotype_call.add(haplotype)
+            for haplotype, count in hapcounts.items():
+                if haplotype not in filtered:
+                    genotype_call.add(haplotype)
             self.data["markers"][marker]["genotype"] = [
                 {"haplotype": ht} for ht in sorted(genotype_call)
             ]
+
+    def allele_counts(self, marker):
+        if marker not in self.data["markers"]:
+            raise IndexError(marker)
+        return self.data["markers"][marker]["typing_result"]
 
     def dump_csv(self, outfile, samplename, counts=True, fix_homo=False):
         max_haps = 0

--- a/microhapulator/tests/data/prof/gujarati-ind1-gt-filt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind1-gt-filt.json
@@ -1,0 +1,108 @@
+{
+    "markers": {
+        "mh06KK-026": {
+            "genotype": [
+                {
+                    "haplotype": "G,C,G"
+                }
+            ],
+            "max_coverage": 3754,
+            "mean_coverage": 3224.5,
+            "min_coverage": 68,
+            "num_discarded_reads": 399,
+            "thresholds": {
+                "dynamic": 66.74,
+                "static": 5
+            },
+            "typing_result": {
+                "C,C,G": 1,
+                "G,A,G": 1,
+                "G,C,G": 3337,
+                "G,C,T": 1,
+                "G,G,G": 2,
+                "G,T,G": 1,
+                "T,C,G": 1
+            }
+        },
+        "mh06KK-080": {
+            "genotype": [
+                {
+                    "haplotype": "C,G"
+                }
+            ],
+            "max_coverage": 3744,
+            "mean_coverage": 3216.3,
+            "min_coverage": 2,
+            "num_discarded_reads": 282,
+            "thresholds": {
+                "dynamic": 68.72,
+                "static": 5
+            },
+            "typing_result": {
+                "C,A": 3,
+                "C,G": 3436,
+                "C,T": 3,
+                "T,G": 1
+            }
+        },
+        "mh06KK-101": {
+            "genotype": [
+                {
+                    "haplotype": "A,A"
+                },
+                {
+                    "haplotype": "G,G"
+                }
+            ],
+            "max_coverage": 3754,
+            "mean_coverage": 3215.0,
+            "min_coverage": 1,
+            "num_discarded_reads": 596,
+            "thresholds": {
+                "dynamic": 62.68,
+                "static": 5
+            },
+            "typing_result": {
+                "A,A": 1577,
+                "A,C": 1,
+                "A,G": 1,
+                "A,T": 1,
+                "G,A": 3,
+                "G,C": 2,
+                "G,G": 1557,
+                "G,T": 2
+            }
+        },
+        "mh07KK-030": {
+            "genotype": [
+                {
+                    "haplotype": "A,C,C"
+                },
+                {
+                    "haplotype": "G,C,C"
+                }
+            ],
+            "max_coverage": 3744,
+            "mean_coverage": 3215.5,
+            "min_coverage": 3,
+            "num_discarded_reads": 406,
+            "thresholds": {
+                "dynamic": 66.4,
+                "static": 5
+            },
+            "typing_result": {
+                "A,C,A": 2,
+                "A,C,C": 1669,
+                "A,T,C": 1,
+                "G,C,A": 2,
+                "G,C,C": 1651,
+                "G,C,G": 1,
+                "G,C,T": 2,
+                "G,T,C": 2,
+                "T,C,C": 1
+            }
+        }
+    },
+    "ploidy": null,
+    "type": "TypingResult"
+}

--- a/microhapulator/tests/data/prof/gujarati-ind2-gt-filt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind2-gt-filt.json
@@ -1,0 +1,95 @@
+{
+    "markers": {
+        "mh06KK-026": {
+            "genotype": [
+                {
+                    "haplotype": "G,C,G"
+                }
+            ],
+            "max_coverage": 3754,
+            "mean_coverage": 3224.4,
+            "min_coverage": 53,
+            "num_discarded_reads": 395,
+            "thresholds": {
+                "static": 10
+            },
+            "typing_result": {
+                "A,C,G": 1,
+                "G,A,G": 3,
+                "G,C,A": 1,
+                "G,C,G": 3338,
+                "G,C,T": 1,
+                "G,G,G": 1,
+                "G,T,G": 1,
+                "T,C,G": 1
+            }
+        },
+        "mh06KK-080": {
+            "genotype": [
+                {
+                    "haplotype": "A,G"
+                },
+                {
+                    "haplotype": "C,G"
+                }
+            ],
+            "max_coverage": 3744,
+            "mean_coverage": 3215.3,
+            "min_coverage": 1,
+            "num_discarded_reads": 345,
+            "thresholds": {
+                "static": 10
+            },
+            "typing_result": {
+                "A,A": 2,
+                "A,G": 1694,
+                "C,A": 2,
+                "C,G": 1681,
+                "T,G": 2
+            }
+        },
+        "mh06KK-101": {
+            "genotype": [
+                {
+                    "haplotype": "G,G"
+                }
+            ],
+            "max_coverage": 3754,
+            "mean_coverage": 3214.9,
+            "min_coverage": 4,
+            "num_discarded_reads": 609,
+            "thresholds": {
+                "static": 10
+            },
+            "typing_result": {
+                "G,A": 3,
+                "G,C": 5,
+                "G,G": 3120,
+                "T,G": 2
+            }
+        },
+        "mh07KK-030": {
+            "genotype": [
+                {
+                    "haplotype": "A,C,C"
+                },
+                {
+                    "haplotype": "G,C,C"
+                }
+            ],
+            "max_coverage": 3744,
+            "mean_coverage": 3224.1,
+            "min_coverage": 64,
+            "num_discarded_reads": 391,
+            "thresholds": {
+                "static": 10
+            },
+            "typing_result": {
+                "A,C,C": 1663,
+                "G,C,C": 1687
+            }
+        }
+    },
+    "ploidy": null,
+    "type": "TypingResult"
+}

--- a/microhapulator/tests/data/prof/gujarati-ind3-gt-filt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind3-gt-filt.json
@@ -1,0 +1,98 @@
+{
+    "markers": {
+        "mh06KK-026": {
+            "genotype": [
+                {
+                    "haplotype": "G,C,G"
+                }
+            ],
+            "max_coverage": 3754,
+            "mean_coverage": 3224.4,
+            "min_coverage": 68,
+            "num_discarded_reads": 412,
+            "thresholds": {
+                "dynamic": 50.085
+            },
+            "typing_result": {
+                "A,C,G": 1,
+                "G,A,G": 1,
+                "G,C,A": 1,
+                "G,C,C": 1,
+                "G,C,G": 3333,
+                "G,C,T": 1,
+                "G,T,G": 1
+            }
+        },
+        "mh06KK-080": {
+            "genotype": [
+                {
+                    "haplotype": "C,G"
+                }
+            ],
+            "max_coverage": 3744,
+            "mean_coverage": 3224.4,
+            "min_coverage": 61,
+            "num_discarded_reads": 324,
+            "thresholds": {
+                "dynamic": 50.955
+            },
+            "typing_result": {
+                "C,A": 4,
+                "C,G": 3391,
+                "C,T": 1,
+                "T,G": 1
+            }
+        },
+        "mh06KK-101": {
+            "genotype": [
+                {
+                    "haplotype": "A,A"
+                },
+                {
+                    "haplotype": "G,G"
+                }
+            ],
+            "max_coverage": 3754,
+            "mean_coverage": 3214.2,
+            "min_coverage": 1,
+            "num_discarded_reads": 593,
+            "thresholds": {
+                "dynamic": 47.28
+            },
+            "typing_result": {
+                "A,A": 1581,
+                "A,C": 1,
+                "A,G": 5,
+                "A,T": 2,
+                "G,A": 2,
+                "G,G": 1560,
+                "G,T": 1
+            }
+        },
+        "mh07KK-030": {
+            "genotype": [
+                {
+                    "haplotype": "A,C,C"
+                }
+            ],
+            "max_coverage": 3744,
+            "mean_coverage": 3215.5,
+            "min_coverage": 1,
+            "num_discarded_reads": 426,
+            "thresholds": {
+                "dynamic": 49.71
+            },
+            "typing_result": {
+                "A,A,C": 3,
+                "A,C,A": 3,
+                "A,C,C": 3302,
+                "A,C,G": 1,
+                "A,C,T": 3,
+                "A,T,C": 1,
+                "C,C,C": 1
+            }
+        }
+    },
+    "ploidy": null,
+    "type": "TypingResult"
+}

--- a/microhapulator/tests/data/prof/gujarati-ind4-gt-filt.json
+++ b/microhapulator/tests/data/prof/gujarati-ind4-gt-filt.json
@@ -1,0 +1,62 @@
+{
+    "markers": {
+        "mh06KK-026": {
+            "genotype": [],
+            "max_coverage": 3754,
+            "mean_coverage": 3215.2,
+            "min_coverage": 1,
+            "num_discarded_reads": 398,
+            "typing_result": {
+                "A,C,G": 1,
+                "C,C,A": 1,
+                "G,C,A": 1674,
+                "G,C,C": 1,
+                "G,C,G": 1672,
+                "G,G,A": 1,
+                "G,T,A": 2,
+                "G,T,G": 2
+            }
+        },
+        "mh06KK-080": {
+            "genotype": [],
+            "max_coverage": 3744,
+            "mean_coverage": 3215.3,
+            "min_coverage": 1,
+            "num_discarded_reads": 305,
+            "typing_result": {
+                "C,G": 3412,
+                "C,T": 1,
+                "T,G": 1
+            }
+        },
+        "mh06KK-101": {
+            "genotype": [],
+            "max_coverage": 3754,
+            "mean_coverage": 3224.3,
+            "min_coverage": 61,
+            "num_discarded_reads": 615,
+            "typing_result": {
+                "A,G": 1,
+                "G,A": 6,
+                "G,C": 5,
+                "G,G": 3111,
+                "G,T": 6
+            }
+        },
+        "mh07KK-030": {
+            "genotype": [],
+            "max_coverage": 3744,
+            "mean_coverage": 3215.8,
+            "min_coverage": 3,
+            "num_discarded_reads": 398,
+            "typing_result": {
+                "A,C,A": 2,
+                "A,C,C": 3338,
+                "C,C,C": 2,
+                "G,C,C": 1
+            }
+        }
+    },
+    "ploidy": null,
+    "type": "TypingResult"
+}

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -71,6 +71,8 @@ def test_pipe_gbr_usc10(tmp_path):
     expected = pd.read_csv(data_file("gbr-usc-profile.csv"))
     observed = pd.read_csv(profile)
     assert observed.equals(expected)
+    pngs = glob(str(tmp_path / "analysis" / "*" / "callplots" / "*.png"))
+    assert len(pngs) == 10
 
 
 @pytest.mark.parametrize(

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -10,6 +10,7 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
+from glob import glob
 import microhapulator
 import microhapulator.api as mhapi
 from microhapulator.profile import SimulatedProfile, TypingResult
@@ -70,3 +71,18 @@ def test_pipe_gbr_usc10(tmp_path):
     expected = pd.read_csv(data_file("gbr-usc-profile.csv"))
     observed = pd.read_csv(profile)
     assert observed.equals(expected)
+
+
+@pytest.mark.parametrize(
+    "filepath,samplename,plotmarker",
+    [
+        ("prof/gujarati-ind1-gt-filt.json", "Guj1", True),
+        ("prof/gujarati-ind2-gt-filt.json", "Guj2", False),
+        ("prof/gujarati-ind3-gt-filt.json", None, True),
+    ],
+)
+def test_plot_haplotype_calls(filepath, samplename, plotmarker, tmp_path):
+    result = TypingResult(fromfile=data_file(filepath))
+    mhapi.plot_haplotype_calls(result, tmp_path, sample=samplename, plot_marker_name=plotmarker)
+    pngs = glob(str(tmp_path / "*.png"))
+    assert len(pngs) == 4


### PR DESCRIPTION
This PR adds a new API function for generating haplotype call plots: a .png is created for each marker, showing read counts of the alleles above the detection threshold, as well as the analytical threshold. This PR also integrates this API call into the `mhpl8r pipe` workflow.

----------

- [x] Changes are clearly described above
- ~~Any relevant issue threads are referenced in the description~~
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
