### PR TITLE
Add different colors to report plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Profiles compatible with probgen programs now included in pipe output (#135).
-- Haplotype call plots now included in the HTML report (#136).
+- Haplotype call plots now included in the pipe HTML report (#136).
 
 ### Changed
 - Exposed static and dynamic threshold configuration to pipe CLI (#135).
+- Updated plot colors in the pipe HTML report (#139).
 
 
 ## [0.6.1] 2022-04-27

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -11,6 +11,7 @@
 # -------------------------------------------------------------------------------------------------
 
 from glob import glob
+from matplotlib import pyplot as plt
 from microhapulator import api as mhapi
 from microhapulator.pipeaux import full_reference_index_files, final_html_report, aggregate_summary
 from microhapulator.profile import TypingResult
@@ -106,13 +107,27 @@ rule read_length_distributions:
         r2="analysis/{sample}/{sample}-r2-read-lengths.png",
         merged="analysis/{sample}/{sample}-merged-read-lengths.png",
     run:
-        mhapi.read_length_dist(input[0], output.r1, title=f"{wildcards.sample} R1")
-        mhapi.read_length_dist(input[1], output.r2, title=f"{wildcards.sample} R2")
+        mhapi.read_length_dist(
+            input[0],
+            output.r1,
+            title=f"{wildcards.sample} R1",
+            color="#e41a1c",
+            edgecolor="#990000",
+        )
+        mhapi.read_length_dist(
+            input[1],
+            output.r2,
+            title=f"{wildcards.sample} R2",
+            color="#e41a1c",
+            edgecolor="#990000",
+        )
         mhapi.read_length_dist(
             input[2],
             output.merged,
             xlabel="Length of Merged Read Pair (bp)",
             title=wildcards.sample,
+            color="#377eb8",
+            edgecolor="#000099",
         )
 
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -62,6 +62,7 @@ def interlocus_balance(
     title=None,
     figsize=(6, 4),
     dpi=200,
+    color=None,
 ):
     """Compute interlocus balance
 
@@ -79,6 +80,7 @@ def interlocus_balance(
     :param str title: add a title (such as a sample name) to the histogram plot
     :param tuple figsize: a 2-tuple of integers indicating the dimensions of the image file to be generated
     :param int dpi: resolution (in dots per inch) of the image file to be generated
+    :param str color: override histogram plot color; green by default
     :return: a tuple (S, C) where S is the chi-square statistic, and C is a table of total read counts for each marker
     :rtype: tuple(float, pandas.DataFrame)
     """
@@ -96,7 +98,9 @@ def interlocus_balance(
         plt.figure(figsize=figsize, dpi=dpi)
         x = range(len(data))
         y = [c / 1000 for c in data.ReadCount]
-        plt.bar(x, y)
+        if color is None:
+            color = "#4daf4a"
+        plt.bar(x, y, color=color)
         plt.xticks([])
         plt.xlabel("Marker", labelpad=15, fontsize=16)
         if include_discarded:
@@ -194,8 +198,8 @@ def heterozygote_balance(
             y1 = data.Allele1Perc
             y2 = data.Allele2Perc
             ylabel = "Percentage of Read Count"
-        ax.bar(x1, y1, width=barwidth)
-        ax.bar(x2, y2, width=barwidth)
+        ax.bar(x1, y1, width=barwidth, color="#984ea3")
+        ax.bar(x2, y2, width=barwidth, color="#ff7f00")
         if dolabels:
             ax.set_xticks(x)
             ax.set_xticklabels(data.Marker, rotation=90)
@@ -572,7 +576,16 @@ def type(bamfile, markertsv, minbasequal=10, max_depth=1e6):
     return result
 
 
-def read_length_dist(fastq, outfile, xlabel="Read Length (bp)", xlim=None, scale=1000, title=None):
+def read_length_dist(
+    fastq,
+    outfile,
+    xlabel="Read Length (bp)",
+    xlim=None,
+    scale=1000,
+    title=None,
+    color=None,
+    edgecolor=None,
+):
     """Plot distribution of read lengths
 
     :param str fastq: path of a FASTQ file containing NGS reads
@@ -581,6 +594,8 @@ def read_length_dist(fastq, outfile, xlabel="Read Length (bp)", xlim=None, scale
     :param tuple xlim: a 2-tuple of numbers (x1, x2) representing the start and end points of the portion of the X axis to be displayed; by default this is determined automatically
     :param float scale: scaling factor for the Y axis
     :param str title: title for the plot
+    :param str color: override histogram plot color; red by default
+    :param str edgecolor: override histogram edge color; dark red by default
     """
     backend = matplotlib.get_backend()
     plt.switch_backend("Agg")
@@ -589,7 +604,13 @@ def read_length_dist(fastq, outfile, xlabel="Read Length (bp)", xlim=None, scale
         for record in SeqIO.parse(fh, "fastq"):
             lengths.append(len(record))
     fig = plt.figure(figsize=(6, 4), dpi=200)
-    plt.hist(lengths, bins=25, weights=[1 / scale] * len(lengths), edgecolor="#000099")
+    if color is None:
+        color = "#e41a1c"
+    if edgecolor is None:
+        edgecolor = "#990000"
+    plt.hist(
+        lengths, bins=25, weights=[1 / scale] * len(lengths), color=color, edgecolor=edgecolor
+    )
     if xlim is None:
         xlim = (min(lengths) * 0.9, max(lengths) * 1.1)
     plt.xlim(*xlim)
@@ -631,7 +652,7 @@ def plot_haplotype_calls(result, outdir, sample=None, plot_marker_name=True, ign
         counts = count_dict.values()
         alleles = count_dict.keys()
         fig = plt.figure(figsize=(4, 4), dpi=150)
-        plt.bar(range(len(counts)), counts)
+        plt.bar(range(len(counts)), counts, color="#999999")
         if len(counts) == 1:
             plt.xticks(range(len(counts)), labels=alleles)
         else:
@@ -640,7 +661,7 @@ def plot_haplotype_calls(result, outdir, sample=None, plot_marker_name=True, ign
         plt.ylabel("Read Count", fontsize=14)
         if "thresholds" in mdata and "dynamic" in mdata["thresholds"]:
             dynamic = mdata["thresholds"]["dynamic"]
-            plt.axhline(y=dynamic, color="red", linestyle="--", label=f"Dynamic Threshold")
+            plt.axhline(y=dynamic, color="#e41a1c", linestyle="--", label=f"Dynamic Threshold")
             plt.legend()
         plt.gca().yaxis.grid(True, color="#DDDDDD")
         plt.gca().set_axisbelow(True)

--- a/microhapulator/cli/locbalance.py
+++ b/microhapulator/cli/locbalance.py
@@ -70,6 +70,12 @@ def subparser(subparsers):
         default=None,
         help="add a title (such as a sample name) to the histogram plot",
     )
+    cli.add_argument(
+        "--color",
+        metavar="C",
+        default=None,
+        help="override histogram plot color; green by default",
+    )
     cli.add_argument("input", help="a typing result including haplotype counts in JSON format")
 
 
@@ -83,6 +89,7 @@ def main(args):
         title=args.title,
         figsize=args.figsize,
         dpi=args.dpi,
+        color=args.color,
     )
     print(f"Extent of imbalance (chi-square statistic): {chisq:.4f}")
     if args.csv:


### PR DESCRIPTION
This PR updates the API to support plotting histograms in the `mhpl8r pipe` report with different colors. Closes #138.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- ~~Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)~~
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
