### PR TITLE
Conditional plotting of read length distributions vs. a summary table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Exposed static and dynamic threshold configuration to pipe CLI (#135).
 - Updated plot colors in the pipe HTML report (#139).
+- Updated pipe HTML report to conditionally plot read length histograms or tables depending on uniformity (#140).
 
 
 ## [0.6.1] 2022-04-27

--- a/microhapulator/Snakefile
+++ b/microhapulator/Snakefile
@@ -105,11 +105,14 @@ rule read_length_distributions:
     output:
         r1="analysis/{sample}/{sample}-r1-read-lengths.png",
         r2="analysis/{sample}/{sample}-r2-read-lengths.png",
+        l1="analysis/{sample}/{sample}-r1-read-lengths.json",
+        l2="analysis/{sample}/{sample}-r2-read-lengths.json",
         merged="analysis/{sample}/{sample}-merged-read-lengths.png",
     run:
         mhapi.read_length_dist(
             input[0],
             output.r1,
+            lengthsfile=output.l1,
             title=f"{wildcards.sample} R1",
             color="#e41a1c",
             edgecolor="#990000",
@@ -117,6 +120,7 @@ rule read_length_distributions:
         mhapi.read_length_dist(
             input[1],
             output.r2,
+            lengthsfile=output.l2,
             title=f"{wildcards.sample} R2",
             color="#e41a1c",
             edgecolor="#990000",

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -26,6 +26,10 @@
                 margin: 12pt auto;
                 width: 100%;
             }
+            table.half {
+                margin: 12pt auto 12pt 0;
+                width: 50%;
+            }
             td, th {
                 padding: auto 5px;
             }
@@ -63,11 +67,29 @@
                 </tr>
                 {% endfor %}
             </table>
+            {% if read_length_table is none %}
             <p>The following histograms show the distribution of R1 and R2 read lengths for each sample.</p>
             {% for r1plot, r2plot in zip(plots["r1readlen"], plots["r2readlen"]) %}
             <img src="data:image/png;base64,{{r1plot}}" class="small" />
             <img src="data:image/png;base64,{{r2plot}}" class="small" />
             {% endfor %}
+            {% else %}
+            <p>Read lengths, uniform for all samples, are shown below.</p>
+            <table class="half">
+                <tr>
+                    <th>Sample</th>
+                    <th class="alnrt">Length R1</th>
+                    <th class="alnrt">Length R2</th>
+                </tr>
+                {% for i, row in read_length_table.iterrows() %}
+                <tr>
+                    <td>{{ row.Sample }}</td>
+                    <td class="alnrt">{{ row.LengthR1 }}</td>
+                    <td class="alnrt">{{ row.LengthR2 }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+            {% endif %}
 
 
             <a name="readmerging"></a>

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -65,6 +65,21 @@ def encode(filepath):
 
 
 def final_html_report(samples, summary):
+    read_length_table = list()
+    for sample in samples:
+        with open(f"analysis/{sample}/{sample}-r1-read-lengths.json") as fh:
+            r1lengths = json.load(fh)
+            r1lengths = list(set(r1lengths))
+        with open(f"analysis/{sample}/{sample}-r2-read-lengths.json") as fh:
+            r2lengths = json.load(fh)
+            r2lengths = list(set(r2lengths))
+        if len(r1lengths) != 1 or len(r2lengths) != 1:
+            read_length_table = None
+            break
+        read_length_table.append((sample, r1lengths[0], r2lengths[0]))
+    if read_length_table is not None:
+        col = ("Sample", "LengthR1", "LengthR2")
+        read_length_table = pd.DataFrame(read_length_table, columns=col)
     plots = {
         "r1readlen": list(),
         "r2readlen": list(),
@@ -92,6 +107,7 @@ def final_html_report(samples, summary):
             static=5,
             dynamic=0.02,
             zip=zip,
+            read_length_table=read_length_table,
         )
         print(output, file=outfh, end="")
 

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -62,7 +62,10 @@ def test_pipe_gbr_usc10(tmp_path):
     observed = TypingResult(fromfile=tmp_path / "analysis" / "gbr-usc" / "gbr-usc-type.json")
     diff = list(mhapi.diff(observed, expected))
     assert len(diff) == 0
-    assert (tmp_path / "report.html").is_file()
+    report = tmp_path / "report.html"
+    assert report.is_file()
+    with open(report, "r") as fh:
+        assert "Read lengths, uniform for all samples, are shown below" in fh.read()
     expected = pd.read_csv(data_file("gbr-usc-summary.tsv"), sep="\t")
     observed = pd.read_csv(tmp_path / "analysis" / "summary.tsv", sep="\t")
     assert observed.equals(expected)


### PR DESCRIPTION
The `mhpl8r pipe` report includes a module for plotting read length distributions.

![Screen Shot 2022-06-17 at 2 42 48 PM](https://user-images.githubusercontent.com/566823/174363371-7e312a98-4328-4b52-ac7b-79aac74e8fb1.png)

However, when all samples have uniform read lengths, you end up with something like...this.

![Screen Shot 2022-06-17 at 2 42 55 PM](https://user-images.githubusercontent.com/566823/174363396-916054a0-8b46-4287-8869-5a06978245e5.png)

This PR replaces these plots with a table of read lengths, when and only when all samples have uniform lengths.

![Screen Shot 2022-06-17 at 2 43 03 PM](https://user-images.githubusercontent.com/566823/174363406-59b90900-c564-4ddc-a8bd-d333d3bc2914.png)

Closes #137.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)