### PR TITLE
fixed numerical sorting on HTML report

### DIFF
--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -305,7 +305,7 @@
                         <tr>
                             <td><a href="marker-detail-report.html?marker={{markername}}" target="_blank">{{markername}}</a></td>
                             {% for sample_data in typing_rates.values()%}
-                            <td class="alnrt">{{"{:,.2f}".format(sample_data.loc[markername, 'TypingRate']*100)}}%</td>
+                            <td class="alnrt" data-sortvalue="{{sample_data.loc[markername, 'TypingRate']}}">{{"{:,.2f}".format(sample_data.loc[markername, 'TypingRate']*100)}}%</td>
                             {% endfor %}
                         </tr>
                         {% endfor %}
@@ -337,8 +337,8 @@
                     {% for marker, row in thresholds.iterrows() %}
                     <tr>
                         <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{marker}}</a></td>
-                        <td class="alnrt">{{row.Static}}</td>
-                        <td class="alnrt">{{"{:.1f}".format(row.Dynamic * 100)}}%</td>
+                        <td class="alnrt" data-sortvalue="{{row.Static}}">{{row.Static}}</td>
+                        <td class="alnrt" data-sortvalue="{{row.Dynamic}}">{{"{:.1f}".format(row.Dynamic * 100)}}%</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     install_requires=[
         "biopython",
         "happer>=0.1",
+        "importlib-metadata>=4.0",
         "insilicoseq>=1.5.4",
         "jsonschema>=4.0",
         "matplotlib>=3.0",

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,10 @@ setup(
     install_requires=[
         "biopython",
         "happer>=0.1",
-        "importlib-metadata>=4.0",
         "insilicoseq>=1.5.4",
         "jsonschema>=4.0",
         "matplotlib>=3.0",
+        "nbformat>=5.0,<5.6",
         "numpy>=1.19",
         "pandas>1.0",
         "scipy>=1.7",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "numpy>=1.19",
         "pandas>1.0",
         "scipy>=1.7",
-        "snakemake>=6.0",
+        "snakemake>=7.15.2",
         "termgraph>=0.5",
         "tqdm>=4.0",
     ],


### PR DESCRIPTION
The columns in the typing rate table and the thresholds table were sorting lexicographically. I updated the tables to sort these columns numerically. Fixes #155 

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- ~[ ] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)~
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- ~[ ] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)~
