### PR TITLE
Trying to fix repetitive read counts

### DIFF
--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -231,6 +231,7 @@ def main(args):
         dryrun=args.dryrun,
         config=config,
         workdir=args.workdir,
+        rerun_triggers=["mtime"],
     )
     if not success:
         return 1


### PR DESCRIPTION

![Screenshot 2023-12-22 at 12 43 54 PM](https://github.com/bioforensics/MicroHapulator/assets/566823/2836b6cf-cb40-464f-a7ac-1adaeaa3a8ab)

We've observed that the number of reads marked as repetitive in the MicroHapulator report exceeds the "total" reads mapped to that marker. This PR is attempting to rectify that discrepancy.

For starters, I've updated the code that counts reads aligned to the whole genome so that it only considers reads that map to the corresponding marker when using marker sequences as the reference.

The screenshot above shows what the results look like prior to my changes, and below shows the results after my changes. There are some differences, but so far my changes have not yet resolved the issue.

![Screenshot 2023-12-22 at 12 41 43 PM](https://github.com/bioforensics/MicroHapulator/assets/566823/7a26300f-41e7-4e61-9b64-94ec3094475a)

----------

- [ ] Changes are clearly described above
- [ ] Any relevant issue threads are referenced in the description
- [ ] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [ ] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [ ] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
