### PR TITLE
Repetitive read count fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).
+- Bug with counting repetitive reads (#163).
 
 
 ## [0.7.2] 2022-10-12

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -702,18 +702,11 @@ def count_repetitive_reads(marker_bam, locus, marker, reads_to_markers_fullref, 
     for read in marker_bam.fetch(locus.id):
         if skip_read(read):
             continue
-        quality_filtered_positions = [
-            pos
-            for i, pos in enumerate(read.get_reference_positions(full_length=True))
-            if read.query_qualities[i] >= minbasequal
-        ]
-        quality_snp_positions = [
-            offset for offset in marker.offsets_locus if offset in quality_filtered_positions
-        ]
-        if (
-            len(quality_snp_positions) > 0
-            and marker.id not in reads_to_markers_fullref[read.query_name]
-        ):
+        ref_pos = read.get_reference_positions(full_length=True)
+        quals = read.query_qualities
+        qual_filtered_pos = [pos for i, pos in enumerate(ref_pos) if quals[i] >= minbasequal]
+        qual_snp_pos = [offset for offset in marker.offsets_locus if offset in qual_filtered_pos]
+        if qual_snp_pos and marker.id not in reads_to_markers_fullref[read.query_name]:
             repetitive_count += 1
     return repetitive_count
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -42,7 +42,6 @@ SimulatedRead = namedtuple("SimulatedRead", ["identifier", "sequence", "quality"
 def count_and_sort(profile, include_discarded=True):
     counts = list()
     for marker, mdata in profile.data["markers"].items():
-        print(mdata)
         readcount = 0
         if include_discarded:
             readcount += mdata["num_discarded_reads"]
@@ -537,7 +536,6 @@ def tally_haplotypes(bam, mhindex, minbasequal=10, max_depth=1e6):
                 aligned_base = record.alignment.query_sequence[record.query_position]
                 ht[record.alignment.query_name][column.pos] = aligned_base
         for readname, htdict in ht.items():
-            print(readname)
             htlist = [htdict[pos] for pos in sorted(htdict)]
             if len(htlist) < len(marker.offsets_locus):
                 discarded += 1

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -700,11 +700,13 @@ def count_repetitive_reads(marker_bam, locus, marker, reads_to_markers_fullref, 
     for read in marker_bam.fetch(locus.id):
         if skip_read(read):
             continue
-        ref_pos = read.get_reference_positions(full_length=True)
+        refr_pos = read.get_reference_positions(full_length=True)
         quals = read.query_qualities
-        qual_filtered_pos = [pos for i, pos in enumerate(ref_pos) if quals[i] >= minbasequal]
+        qual_filtered_pos = [pos for pos, qual in zip(refr_pos, quals) if qual >= minbasequal]
         qual_snp_pos = [offset for offset in marker.offsets_locus if offset in qual_filtered_pos]
-        if qual_snp_pos and marker.id not in reads_to_markers_fullref[read.query_name]:
+        read_overlaps_target_snps = len(qual_snp_pos) > 0
+        read_maps_elsewhere = marker.id not in reads_to_markers_fullref[read.query_name]
+        if read_overlaps_target_snps and read_maps_elsewhere:
             repetitive_count += 1
     return repetitive_count
 

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -160,10 +160,10 @@ def final_html_report(
 def read_length_table_paired_end(samples):
     read_length_data = list()
     for sample in samples:
-        with open(f"analysis/{sample}/{sample}-r1-read-lengths.json") as fh:
+        with open(f"analysis/{sample}/{sample}-r1-read-lengths.json", "r") as fh:
             r1lengths = json.load(fh)
             r1lengths = list(set(r1lengths))
-        with open(f"analysis/{sample}/{sample}-r2-read-lengths.json") as fh:
+        with open(f"analysis/{sample}/{sample}-r2-read-lengths.json", "r") as fh:
             r2lengths = json.load(fh)
             r2lengths = list(set(r2lengths))
         if len(r1lengths) != 1 or len(r2lengths) != 1:
@@ -176,7 +176,7 @@ def read_length_table_paired_end(samples):
 def read_length_table_single_end(samples):
     read_length_data = list()
     for sample in samples:
-        with open(f"analysis/{sample}/{sample}-read-lengths.json") as fh:
+        with open(f"analysis/{sample}/{sample}-read-lengths.json", "r") as fh:
             lengths = json.load(fh)
             lengths = list(set(lengths))
         if len(lengths) != 1:

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -257,9 +257,9 @@ rule download_and_index_full_reference:
 
 rule repetitive_mapping:
     input:
-        marker_bam=rules.map_sort_and_index.output.bam,
-        fullref_bam=rules.map_full_reference.output.bam,
-        marker_def=rules.copy_and_index_marker_data.output.tsv,
+        marker_bam="analysis/{sample}/{sample}.bam",
+        fullref_bam="analysis/{sample}/fullrefr/{sample}-fullrefr.bam",
+        marker_def="marker-definitions.tsv",
     output:
         counts="analysis/{sample}/{sample}-repetitive-reads.csv",
     run:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "nbformat>=5.0,<5.6",
         "numpy>=1.19",
         "pandas>1.0",
-        "pulp=2.3.1",
+        "pulp==2.3.1",
         "scipy>=1.7",
         "snakemake>=7.15.2,<8.0",
         "termgraph>=0.5",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "numpy>=1.19",
         "pandas>1.0",
         "scipy>=1.7",
-        "snakemake>=7.15.2",
+        "snakemake>=7.15.2,<8.0",
         "termgraph>=0.5",
         "tqdm>=4.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "nbformat>=5.0,<5.6",
         "numpy>=1.19",
         "pandas>1.0",
+        "pulp=2.3.1",
         "scipy>=1.7",
         "snakemake>=7.15.2,<8.0",
         "termgraph>=0.5",


### PR DESCRIPTION
We observed some cases where the number of repetitive reads was exceeding the number of total reads. This is due to counting repetitive reads at the locus level rather than the marker level. This PR fixes that issue and refactors some code to make the logic more clear. 

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [ x Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
