### PR TITLE
Ridge plots for read length distributions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Smart handling of multiple markers at a single locus implemented for `type` and `pipe` (#158).
 - Replaced `parsers` module with a `MicrohapIndex` class and supporting classes (#158).
+- Replaced read length distubition histograms with ridge plots (#167)
 
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -578,7 +578,24 @@ def type(bamfile, markertsv, minbasequal=10, max_depth=1e6):
     return result
 
 
-def read_length_dist(
+def calculate_read_lengths(
+    fastq,
+    lengthsfile,
+):
+    """Count read lengths
+
+    :param str fastq: path of a FASTQ file containing NGS reads
+    :param str lengthsfile: file to write read lengths to
+    """
+    lengths = list()
+    with mhopen(fastq, "r") as infh:
+        for record in SeqIO.parse(infh, "fastq"):
+            lengths.append(len(record))
+    with mhopen(lengthsfile, "w") as outfh:
+        json.dump(lengths, outfh)
+
+
+def plot_read_length_dist(
     lengthfiles,
     plotfile,
     samples,
@@ -645,23 +662,6 @@ def read_distribution_plot_label(sample_subset, color, label):
         va="center",
         transform=ax.transAxes,
     )
-
-
-def read_length_counts(
-    fastq,
-    lengthsfile,
-):
-    """Count read lengths
-
-    :param str fastq: path of a FASTQ file containing NGS reads
-    :param str lengthsfile: file to write read lengths to
-    """
-    lengths = list()
-    with mhopen(fastq, "r") as infh:
-        for record in SeqIO.parse(infh, "fastq"):
-            lengths.append(len(record))
-    with mhopen(lengthsfile, "w") as outfh:
-        json.dump(lengths, outfh)
 
 
 def plot_haplotype_calls(result, outdir, sample=None, plot_marker_name=True, ignore_low=True):

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -601,9 +601,8 @@ def read_length_dist(
     samples,
     hspace=-0.7,
     xlabel="Read Length (bp)",
-    title=None,
-    color="red",
-    edgecolor="black",
+    color=None,
+    edgecolor=None,
 ):
     """Plot distribution of read lengths
     :param list lengthsfiles: list of JSON files containing read lengths for each sample
@@ -630,8 +629,6 @@ def read_length_dist(
     plt.xlabel(xlabel, fontsize=18)
     plt.xticks(fontsize=18)
     grid.despine(left=True)
-    if title:
-        plt.suptitle(title, fontsize=18, y=1.05)
     plt.savefig(plotfile, bbox_inches="tight")
     plt.switch_backend(backend)
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -595,7 +595,7 @@ def calculate_read_lengths(
         json.dump(lengths, outfh)
 
 
-def plot_read_length_dist(
+def read_length_dist(
     lengthfiles,
     plotfile,
     samples,

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -631,7 +631,7 @@ def read_length_dist(
     plt.xticks(fontsize=18)
     grid.despine(left=True)
     if title:
-        plt.title(title, fontsize=18, pad=35)
+        plt.suptitle(title, fontsize=18, y=1.05)
     plt.savefig(plotfile, bbox_inches="tight")
     plt.switch_backend(backend)
 

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -188,6 +188,12 @@ def subparser(subparsers):
         # Hidden option for testing purposes
     )
     cli.add_argument(
+        "--hspace",
+        metavar="HS",
+        default=-0.7,
+        help="Hhorizontal spacing between samples in the read distribution length ridge plots; negative value for this parameter enables overlapping plots; HS=-0.7 by default",
+    )
+    cli.add_argument(
         "markerrefr", help="path to a FASTA file containing marker reference sequences"
     )
     cli.add_argument("markerdefn", help="path to a TSV file containing marker definitions")
@@ -222,6 +228,7 @@ def main(args):
         thresh_dynamic=args.dynamic,
         thresh_file=args.config,
         paired=args.reads_are_paired,
+        hspace=args.hspace,
     )
     snakefile = resource_filename("microhapulator", "workflows/analysis.smk")
     success = snakemake(

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -191,7 +191,7 @@ def subparser(subparsers):
         "--hspace",
         metavar="HS",
         default=-0.7,
-        help="Hhorizontal spacing between samples in the read distribution length ridge plots; negative value for this parameter enables overlapping plots; HS=-0.7 by default",
+        help="horizontal spacing between samples in the read distribution length ridge plots; negative value for this parameter enables overlapping plots; HS=-0.7 by default",
     )
     cli.add_argument(
         "markerrefr", help="path to a FASTA file containing marker reference sequences"

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -21,6 +21,11 @@
             img.small {
                 width: 24.5%;
             }
+            img.center {
+                display: block;
+                margin-left: auto;
+                margin-right: auto;
+            }
             .fullwidth {
                 width: 100%;
             }
@@ -119,7 +124,7 @@
                     <img src="analysis/r2-read-lengths.png"/>
                 {% else %}
                     <p>The following ridge plot shows read length distributions for each sample.</p>
-                    <img class="fullwidth" src="analysis/read-lengths.png"/>
+                    <img class="center" src="analysis/read-lengths.png"/>
                 {% endif %}
             {% else %}
                 <p>Read lengths, uniform for all samples, are shown below.</p>
@@ -175,7 +180,7 @@
                 {% endfor %}
             </table>
             <p>The following ridge plot shows the distribution of merged read lengths for each sample.</p>
-            <img class=fullwidth src="analysis/merged-read-lengths.png"/>
+            <img class=center src="analysis/merged-read-lengths.png"/>
             {% endif %}
 
             <a name="readmapping"></a>

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -114,12 +114,12 @@
 
             {% if read_length_table is none %}
                 {% if "r1readlen" in plots %}
-                    <p>The following histograms show the distribution of R1 and R2 read lengths for each sample.</p>
+                    <p>The following ridge plots show the distribution of R1 and R2 read lengths for each sample.</p>
                     <img src="analysis/r1-read-lengths.png"/>
                     <img src="analysis/r2-read-lengths.png"/>
                 {% else %}
-                    <p>The following histograms show read length distributions for each sample.</p>
-                    <img src="analysis/read-lengths.png"/>
+                    <p>The following ridge plot shows read length distributions for each sample.</p>
+                    <img class="fullwidth" src="analysis/read-lengths.png"/>
                 {% endif %}
             {% else %}
                 <p>Read lengths, uniform for all samples, are shown below.</p>
@@ -174,8 +174,8 @@
                 </tr>
                 {% endfor %}
             </table>
-            <p>The following histograms show the distribution of merged read lengths for each sample.</p>
-            <img src="analysis/merged-read-lengths.png"/>
+            <p>The following ridge plot shows the distribution of merged read lengths for each sample.</p>
+            <img class=fullwidth src="analysis/merged-read-lengths.png"/>
             {% endif %}
 
             <a name="readmapping"></a>

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -115,15 +115,11 @@
             {% if read_length_table is none %}
                 {% if "r1readlen" in plots %}
                     <p>The following histograms show the distribution of R1 and R2 read lengths for each sample.</p>
-                    {% for r1plot, r2plot in zip(plots["r1readlen"], plots["r2readlen"]) %}
-                    <img src={{r1plot}} class="small" />
-                    <img src={{r2plot}} class="small" />
-                    {% endfor %}
+                    <img src="analysis/r1-read-lengths.png"/>
+                    <img src="analysis/r2-read-lengths.png"/>
                 {% else %}
                     <p>The following histograms show read length distributions for each sample.</p>
-                    {% for rlplot in plots["readlen"] %}
-                    <img src="{{rlplot}}" class="small" />
-                    {% endfor %}
+                    <img src="analysis/read-lengths.png"/>
                 {% endif %}
             {% else %}
                 <p>Read lengths, uniform for all samples, are shown below.</p>
@@ -179,9 +175,7 @@
                 {% endfor %}
             </table>
             <p>The following histograms show the distribution of merged read lengths for each sample.</p>
-            {% for plot in plots["mergedreadlen"] %}
-            <img src="{{plot}}" />
-            {% endfor %}
+            <img src="analysis/merged-read-lengths.png"/>
             {% endif %}
 
             <a name="readmapping"></a>

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -187,17 +187,17 @@ def read_length_table_single_end(samples):
 
 def aggregate_plots_paired_end(samples):
     plots = {
-        "r1readlen": list(),
-        "r2readlen": list(),
-        "mergedreadlen": list(),
+        "r1readlen": str,
+        "r2readlen": str,
+        "mergedreadlen": str,
         "locbalance": list(),
         "hetbalance": list(),
         "donut": list(),
     }
+    plots["r1readlen"] = f"analysis/r1-read-lengths.png"
+    plots["r2readlen"] = f"analysis/r2-read-lengths.png"
+    plots["mergedreadlen"] = f"analysis/merged-read-lengths.png"
     for sample in samples:
-        plots["r1readlen"].append(f"analysis/{sample}/{sample}-r1-read-lengths.png")
-        plots["r2readlen"].append(f"analysis/{sample}/{sample}-r2-read-lengths.png")
-        plots["mergedreadlen"].append(f"analysis/{sample}/{sample}-merged-read-lengths.png")
         plots["locbalance"].append(f"analysis/{sample}/{sample}-interlocus-balance.png")
         plots["hetbalance"].append(f"analysis/{sample}/{sample}-heterozygote-balance.png")
         plots["donut"].append(f"analysis/{sample}/{sample}-donut.png")
@@ -205,9 +205,9 @@ def aggregate_plots_paired_end(samples):
 
 
 def aggregate_plots_single_end(samples):
-    plots = {"readlen": list(), "locbalance": list(), "hetbalance": list(), "donut": list()}
+    plots = {"readlen": str, "locbalance": list(), "hetbalance": list(), "donut": list()}
+    plots["readlen"] = f"analysis/read-lengths.png"
     for sample in samples:
-        plots["readlen"].append(f"analysis/{sample}/{sample}-read-lengths.png")
         plots["locbalance"].append(f"analysis/{sample}/{sample}-interlocus-balance.png")
         plots["hetbalance"].append(f"analysis/{sample}/{sample}-heterozygote-balance.png")
         plots["donut"].append(f"analysis/{sample}/{sample}-donut.png")

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -187,9 +187,9 @@ def read_length_table_single_end(samples):
 
 def aggregate_plots_paired_end(samples):
     plots = {
-        "r1readlen": str,
-        "r2readlen": str,
-        "mergedreadlen": str,
+        "r1readlen": "",
+        "r2readlen": "",
+        "mergedreadlen": "",
         "locbalance": list(),
         "hetbalance": list(),
         "donut": list(),
@@ -205,7 +205,7 @@ def aggregate_plots_paired_end(samples):
 
 
 def aggregate_plots_single_end(samples):
-    plots = {"readlen": str, "locbalance": list(), "hetbalance": list(), "donut": list()}
+    plots = {"readlen": "", "locbalance": list(), "hetbalance": list(), "donut": list()}
     plots["readlen"] = f"analysis/read-lengths.png"
     for sample in samples:
         plots["locbalance"].append(f"analysis/{sample}/{sample}-interlocus-balance.png")

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -100,20 +100,25 @@ rule plot_read_length_distributions:
             output.r1,
             config["samples"],
             config["hspace"],
-            title="R1 Length Distribution",
+            xlabel="R1 Read Length (bp)",
+            color="#e41a1c",
+            edgecolor="#990000",
         )
         mhapi.read_length_dist(
             input.r2s,
             output.r2,
             config["samples"],
             config["hspace"],
-            title="R2 Length Distribution",
+            xlabel="R2 Read Length (bp)",
+            color="#e41a1c",
+            edgecolor="#990000",
         )
         mhapi.read_length_dist(
             input.merged,
             output.merged,
             config["samples"],
             config["hspace"],
-            title="Merged Read Length Distribution",
-            color="blue",
+            xlabel="Merged Read Length (bp)",
+            color="#377eb8",
+            edgecolor="#3355aa",
         )

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -95,21 +95,21 @@ rule plot_read_length_distributions:
         r2="analysis/r2-read-lengths.png",
         merged="analysis/merged-read-lengths.png",
     run:
-        mhapi.plot_read_length_dist(
+        mhapi.read_length_dist(
             input.r1s,
             output.r1,
             config["samples"],
             config["hspace"],
             title="R1 Length Distribution",
         )
-        mhapi.plot_read_length_dist(
+        mhapi.read_length_dist(
             input.r2s,
             output.r2,
             config["samples"],
             config["hspace"],
             title="R2 Length Distribution",
         )
-        mhapi.plot_read_length_dist(
+        mhapi.read_length_dist(
             input.merged,
             output.merged,
             config["samples"],

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -115,4 +115,5 @@ rule plot_read_length_distributions:
             config["samples"],
             config["hspace"],
             title="Merged Read Length Distribution",
+            color="blue",
         )

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -63,7 +63,7 @@ rule merge:
         """
 
 
-rule read_length_counts:
+rule calculate_read_lengths:
     input:
         lambda wildcards: sorted([fq for fq in config["readfiles"] if wildcards.sample in fq]),
         rules.merge.output.linkedfq,
@@ -72,18 +72,18 @@ rule read_length_counts:
         l2="analysis/{sample}/{sample}-r2-read-lengths.json",
         merged="analysis/{sample}/{sample}-merged-read-lengths.json",
     run:
-        mhapi.read_length_counts(
+        mhapi.calculate_read_lengths(
             input[0],
             output.l1,
         )
-        mhapi.read_length_counts(
+        mhapi.calculate_read_lengths(
             input[1],
             output.l2,
         )
-        mhapi.read_length_counts(input[2], output.merged)
+        mhapi.calculate_read_lengths(input[2], output.merged)
 
 
-rule read_length_distributions:
+rule plot_read_length_distributions:
     input:
         r1s=expand("analysis/{sample}/{sample}-r1-read-lengths.json", sample=config["samples"]),
         r2s=expand("analysis/{sample}/{sample}-r2-read-lengths.json", sample=config["samples"]),
@@ -95,21 +95,21 @@ rule read_length_distributions:
         r2="analysis/r2-read-lengths.png",
         merged="analysis/merged-read-lengths.png",
     run:
-        mhapi.read_length_dist(
+        mhapi.plot_read_length_dist(
             input.r1s,
             output.r1,
             config["samples"],
             config["hspace"],
             title="R1 Length Distribution",
         )
-        mhapi.read_length_dist(
+        mhapi.plot_read_length_dist(
             input.r2s,
             output.r2,
             config["samples"],
             config["hspace"],
             title="R2 Length Distribution",
         )
-        mhapi.read_length_dist(
+        mhapi.plot_read_length_dist(
             input.merged,
             output.merged,
             config["samples"],

--- a/microhapulator/workflows/preproc-single.smk
+++ b/microhapulator/workflows/preproc-single.smk
@@ -16,8 +16,8 @@ from microhapulator.pipeaux import full_reference_index_files
 from os import symlink
 
 preproc_aux_files = chain(
-    expand("analysis/{sample}/{sample}-read-lengths.png", sample=config["samples"]),
     expand("analysis/{sample}/fastqc/report.html", sample=config["samples"]),
+    ["analysis/read-lengths.png"],
 )
 
 summary_aux_files = list()
@@ -50,18 +50,28 @@ rule fastq_reads:
             shell("cp {input[0]} {output.fastq}")
 
 
-rule read_length_distributions:
+rule read_length_counts:
     input:
         rules.fastq_reads.output.fastq,
     output:
-        png="analysis/{sample}/{sample}-read-lengths.png",
         json="analysis/{sample}/{sample}-read-lengths.json",
     run:
-        mhapi.read_length_dist(
+        mhapi.read_length_counts(
             input[0],
+            output.json,
+        )
+
+
+rule read_length_distributions:
+    input:
+        reads=expand("analysis/{sample}/{sample}-read-lengths.json", sample=config["samples"]),
+    output:
+        png="analysis/read-lengths.png",
+    run:
+        mhapi.read_length_dist(
+            input.reads,
             output.png,
-            lengthsfile=output.json,
-            title=wildcards.sample,
-            color="#e41a1c",
-            edgecolor="#990000",
+            config["samples"],
+            config["hspace"],
+            title="Read Length Distribution",
         )

--- a/microhapulator/workflows/preproc-single.smk
+++ b/microhapulator/workflows/preproc-single.smk
@@ -68,7 +68,7 @@ rule plot_read_length_distributions:
     output:
         png="analysis/read-lengths.png",
     run:
-        mhapi.plot_read_length_dist(
+        mhapi.read_length_dist(
             input.reads,
             output.png,
             config["samples"],

--- a/microhapulator/workflows/preproc-single.smk
+++ b/microhapulator/workflows/preproc-single.smk
@@ -73,5 +73,7 @@ rule plot_read_length_distributions:
             output.png,
             config["samples"],
             config["hspace"],
-            title="Read Length Distribution",
+            xlabel="Read Length (bp)",
+            color="#e41a1c",
+            edgecolor="#990000",
         )

--- a/microhapulator/workflows/preproc-single.smk
+++ b/microhapulator/workflows/preproc-single.smk
@@ -50,25 +50,25 @@ rule fastq_reads:
             shell("cp {input[0]} {output.fastq}")
 
 
-rule read_length_counts:
+rule calculate_read_lengths:
     input:
         rules.fastq_reads.output.fastq,
     output:
         json="analysis/{sample}/{sample}-read-lengths.json",
     run:
-        mhapi.read_length_counts(
+        mhapi.calculate_read_lengths(
             input[0],
             output.json,
         )
 
 
-rule read_length_distributions:
+rule plot_read_length_distributions:
     input:
         reads=expand("analysis/{sample}/{sample}-read-lengths.json", sample=config["samples"]),
     output:
         png="analysis/read-lengths.png",
     run:
-        mhapi.read_length_dist(
+        mhapi.plot_read_length_dist(
             input.reads,
             output.png,
             config["samples"],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         "biopython",
         "happer>=0.1",
-        "insilicoseq>=1.5.4",
+        "insilicoseq<2.0",
         "jsonschema>=4.0",
         "matplotlib>=3.0",
         "microhapdb>=0.10.1",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         "biopython",
         "happer>=0.1",
-        "insilicoseq<2.0",
+        "insilicoseq>=1.5.4,<2.0",
         "jsonschema>=4.0",
         "matplotlib>=3.0",
         "microhapdb>=0.10.1",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "pandas>1.0",
         "pulp==2.3.1",
         "scipy>=1.7",
+        "seaborn>=0.13.2",
         "snakemake>=7.15.2,<8.0",
         "termgraph>=0.5",
         "tqdm>=4.0",


### PR DESCRIPTION
This pull request addresses part of #160 and updates the read length distribution plots in the report to ridge plots rather than individual plots for each sample. Previously, writing the read lengths to `json` files and plotting the distributions was done with a single function. This PR breaks these into 2 different functions for 2 reasons:  1) Writing the read lengths to `json` files still needs to be done on a per sample basis while plotting is now done for all samples at once. and 2) If the `json` files already exist, the plot can be regenerated without having to recalculate the read lengths. A new command line parameter `--hspace` was also added to adjust the spacing between subplots in the ridge plots to accommodate a wide range of sample numbers. 

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
