### PR TITLE
Replace donut plots with stacked bar graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Smart handling of multiple markers at a single locus implemented for `type` and `pipe` (#158).
 - Replaced `parsers` module with a `MicrohapIndex` class and supporting classes (#158).
-- Replaced read length distubition histograms with ridge plots (#167)
+- Replaced read length distubition histograms with ridge plots (#167).
+- Replaced read QC donut plots with a stacked bar chart (#168).
 
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -783,6 +783,7 @@ def aggregate_read_mapping_qc(samples, outpath):
     axes.spines["right"].set_visible(False)
     axes.spines["left"].set_visible(False)
     axes.spines["bottom"].set_color("#CCCCCC")
+    plt.legend(loc="lower left", ncols=4, bbox_to_anchor=(0, 1))
     plt.savefig(outpath, bbox_inches="tight")
     plt.switch_backend(backend)
 

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -764,14 +764,48 @@ def repetitive_mapping(marker_bam_file, fullref_bam_file, markertsv, minbasequal
     return data
 
 
+def aggregate_read_mapping_qc(samples, outpath):
+    """Aggregate per-sample read mapping stats and plot as a stacked bar graph
+
+    :param list samples: list of sample names
+    :param str outpath: path to image file to be generated
+    """
+    read_qc = consolidate_read_mapping_qc_tables(samples)
+    backend = matplotlib.get_backend()
+    plt.switch_backend("Agg")
+    axes = read_qc.plot(kind="barh", stacked=True, width=0.8)
+    axes.get_figure().set(dpi=200, figheight=len(samples) * 0.25, figwidth=8)
+    axes.set_xlabel("Reads")
+    axes.set_yticks(range(len(read_qc)), labels=read_qc.Sample)
+    axes.xaxis.grid(True, color="#DDDDDD")
+    axes.set_axisbelow(True)
+    axes.spines["top"].set_visible(False)
+    axes.spines["right"].set_visible(False)
+    axes.spines["left"].set_visible(False)
+    axes.spines["bottom"].set_color("#CCCCCC")
+    plt.savefig(outpath, bbox_inches="tight")
+    plt.switch_backend(backend)
+
+
+def consolidate_read_mapping_qc_tables(samples):
+    sample_qc_tables = list()
+    for sample in samples:
+        infile = f"analysis/{sample}/{sample}-read-mapping-qc.csv"
+        sample_qc_table = pd.read_csv(infile)
+        sample_qc_table["Sample"] = sample
+        sample_qc_tables.append(sample_qc_table)
+    aggregate_qc_table = pd.concat(sample_qc_tables).sort_values("Sample", ascending=False)
+    return aggregate_qc_table
+
+
 def read_mapping_qc(marker_mapped, refr_mapped, repetitive_mapped, figure, title=None):
     """Count on target, off target, repetitive, and contaminant reads
+
     :param str marker_mapped: path of txt file containing number of reads mapped to marker sequences
     :param str refr_mapped: path of txt file containing number of reads mapped to the full human reference genome
     :param str repetitive_mapped: path of txt file containing number of reads mapped preferentially to non-marker loci in the human reference genome
     :param str output: path where the png file of the plot will be saved
     :param str sample: name of the sample to be included as the plot title; by default no sample name is shown
-
     """
     data = count_mapped_read_types(marker_mapped, refr_mapped, repetitive_mapped)
     backend = matplotlib.get_backend()

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -120,11 +120,11 @@
             {% if read_length_table is none %}
                 {% if "r1readlen" in plots %}
                     <p>The following ridge plots show the distribution of R1 and R2 read lengths for each sample.</p>
-                    <img src="analysis/r1-read-lengths.png"/>
-                    <img src="analysis/r2-read-lengths.png"/>
+                    <img src="analysis/r1-read-lengths.png" />
+                    <img src="analysis/r2-read-lengths.png" />
                 {% else %}
                     <p>The following ridge plot shows read length distributions for each sample.</p>
-                    <img class="center" src="analysis/read-lengths.png"/>
+                    <img class="center" src="analysis/read-lengths.png" />
                 {% endif %}
             {% else %}
                 <p>Read lengths, uniform for all samples, are shown below.</p>
@@ -180,7 +180,7 @@
                 {% endfor %}
             </table>
             <p>The following ridge plot shows the distribution of merged read lengths for each sample.</p>
-            <img class=center src="analysis/merged-read-lengths.png"/>
+            <img class="center" src="analysis/merged-read-lengths.png" />
             {% endif %}
 
             <a name="readmapping"></a>
@@ -221,7 +221,7 @@
             <br />
 
             <p> The following bar graph shows the proportions of on target, repetitive, off target, and cotaminant reads. On target reads are those reads that align preferentially to the marker locus when aligned to the full human reference genome. Repetitive reads align to a marker sequence but preferentially align to a different locus when aligned to the full reference. Off target reads do not align to any marker sequences but do align elsewhere in the human genome. Lastly, contaminant reads do not align anywhere in the human genome.</p>
-            <img src="analysis/read-mapping-qc.png" />
+            <img class="fullwidth" src="analysis/read-mapping-qc.png" />
             <br />
             <br />
             <p>The following table shows the number of total reads mapped to each marker for each sample. Also shown is the number of repetitive reads, determined by selecting the reads aligned to the marker, mapping them to the entire GRCh38 human reference sequence, and counting the reads that map preferentially to a locus outside the target marker locus.</p>

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -7,6 +7,9 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
         <script src="fancyTable.js"></script>
         <style type="text/css">
+            h2 {
+                margin-top: 50px;
+            }
             .container {
                 max-width: 750px;
                 padding-top: 100px;

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -221,11 +221,8 @@
             </div>
             <br />
 
-            <p> The following donut plots show the proportions of on target, repetitive, off target, and cotaminant reads. On target reads are those reads that align preferentially to the marker locus when aligned to the full human reference genome. Repetitive reads align to a marker sequence but preferentially align to a different locus when aligned to the full reference. Off target reads do not align to any marker sequences but do align elsewhere in the human genome. Lastly, contaminant reads do not align anywhere in the human genome.</p>
-       
-            {% for plot in plots["donut"] %}
-            <img src="{{plot}}"/>
-            {% endfor %}
+            <p> The following bar graph shows the proportions of on target, repetitive, off target, and cotaminant reads. On target reads are those reads that align preferentially to the marker locus when aligned to the full human reference genome. Repetitive reads align to a marker sequence but preferentially align to a different locus when aligned to the full reference. Off target reads do not align to any marker sequences but do align elsewhere in the human genome. Lastly, contaminant reads do not align anywhere in the human genome.</p>
+            <img src="analysis/read-mapping-qc.png" />
             <br />
             <br />
             <p>The following table shows the number of total reads mapped to each marker for each sample. Also shown is the number of repetitive reads, determined by selecting the reads aligned to the marker, mapping them to the entire GRCh38 human reference sequence, and counting the reads that map preferentially to a locus outside the target marker locus.</p>

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -85,8 +85,7 @@ def test_pipe_gbr_usc10(tmp_path):
     assert observed.equals(expected)
     call_pngs = glob(str(tmp_path / "analysis" / "*" / "callplots" / "*.png"))
     assert len(call_pngs) == 10
-    donut_pngs = glob(str(tmp_path / "analysis" / "gbr-usc" / "gbr-usc-donut.png"))
-    assert len(donut_pngs) == 1
+    assert (tmp_path / "analysis" / "read-mapping-qc.png").is_file()
 
 
 def test_pipe_jpt_usc10_single(tmp_path):

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -292,24 +292,4 @@ rule aggregate_read_mapping_qc:
     output:
         plot="analysis/read-mapping-qc.png",
     run:
-        sample_qc_tables = list()
-        for sample in config["samples"]:
-            infile = f"analysis/{sample}/{sample}-read-mapping-qc.csv"
-            sample_qc_table = pd.read_csv(infile)
-            sample_qc_table["Sample"] = sample
-            sample_qc_tables.append(sample_qc_table)
-        read_qc = pd.concat(sample_qc_tables).sort_values("Sample", ascending=False)
-        backend = matplotlib.get_backend()
-        plt.switch_backend("Agg")
-        axes = read_qc.plot(kind="barh", stacked=True, width=0.8)
-        axes.get_figure().set(dpi=200, figheight=len(config["samples"]) * 0.25, figwidth=6)
-        axes.set_xlabel("Reads")
-        axes.set_yticks(range(len(read_qc)), labels=read_qc.Sample)
-        axes.xaxis.grid(True, color="#DDDDDD")
-        axes.set_axisbelow(True)
-        axes.spines["top"].set_visible(False)
-        axes.spines["right"].set_visible(False)
-        axes.spines["left"].set_visible(False)
-        axes.spines["bottom"].set_color("#CCCCCC")
-        plt.savefig(output.plot, bbox_inches="tight")
-        plt.switch_backend(backend)
+        mhapi.aggregate_read_mapping_qc(config["samples"], output.plot)

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -282,3 +282,28 @@ rule read_mapping_qc:
         """
         mhpl8r mappingqc  --marker {input.marker} --refr {input.full_refr} --rep {input.repetitive}  --csv {output.counts}  --figure {output.plot} --title {wildcards.sample}
         """
+
+
+rule aggregate_read_mapping_qc:
+    input:
+        expand("analysis/{sample}/{sample}-read-mapping-qc.csv"),
+    output:
+        plot="analysis/read-mapping-qc.png",
+    run:
+        read_qc = pd.concat([pd.read_csv(infile) for infile in input]).sort_values(
+            "Sample", ascending=False
+        )
+        backend = matplotlib.get_backend()
+        plt.switch_backend("Agg")
+        axes = qcdata.plot(kind="barh", stacked=True, width=0.8)
+        axes.get_figure().set(dpi=200, figheight=4, figwidth=6)
+        axes.set_xlabel("Reads")
+        axes.set_yticks(range(len(qcdata)), labels=qcdata.Sample)
+        axes.xaxis.grid(True, color="#DDDDDD")
+        axes.set_axisbelow(True)
+        axes.spines["top"].set_visible(False)
+        axes.spines["right"].set_visible(False)
+        axes.spines["left"].set_visible(False)
+        axes.spines["bottom"].set_color("#CCCCCC")
+        plt.savefig(output.plot, bbox_inches="tight")
+        plt.switch_backend(backend)

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -302,7 +302,7 @@ rule aggregate_read_mapping_qc:
         backend = matplotlib.get_backend()
         plt.switch_backend("Agg")
         axes = read_qc.plot(kind="barh", stacked=True, width=0.8)
-        axes.get_figure().set(dpi=200, figheight=len(config["samples"] * 0.66), figwidth=6)
+        axes.get_figure().set(dpi=200, figheight=len(config["samples"]) * 0.25, figwidth=6)
         axes.set_xlabel("Reads")
         axes.set_yticks(range(len(read_qc)), labels=read_qc.Sample)
         axes.xaxis.grid(True, color="#DDDDDD")


### PR DESCRIPTION
Currently, a breakdown of reads by category (on target, off target, repetitive, and contamination) is displayed in the report as a grid of donut plots, one per sample. This PR replaces these donut plots with a single stacked bar chart. It is shown in horizontal orientation so that the height of the plot can grow as the number of samples grows.

![read-mapping-qc](https://github.com/bioforensics/MicroHapulator/assets/566823/47f2c10a-6a86-480f-8c90-24a5d3ce0f92)

Related to #160.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
