### PR TITLE
Add MultiQC plots to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Replaced `parsers` module with a `MicrohapIndex` class and supporting classes (#158).
 - Replaced read length distubition histograms with ridge plots (#167).
 - Replaced read QC donut plots with a stacked bar chart (#168).
+- Replaced FastQC report links with MultiQC link (#169).
 
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test4:
 devdeps:
 	pip install --upgrade pip setuptools
 	pip install wheel twine
-	pip install 'black==22.3' 'snakefmt==0.6' 'pytest>=6.0' pytest-cov pytest-xdist myst-parser sphinx sphinx-argparse
+	pip install 'black<25.0.0,>=24.1.1' 'snakefmt>=0.10.0' 'pytest>=6.0' pytest-cov pytest-xdist myst-parser sphinx sphinx-argparse
 
 ## doc:       build HTML documentation
 doc:

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -94,32 +94,10 @@
 
             <a name="readqc"></a>
             <h2>Read QA/QC</h2>
-            <p>QC reports for the input reads are generated using <a href="https://www.bioinformatics.babraham.ac.uk/projects/fastqc/" target="_blank">FastQC</a>. Links to reports for each sample are provided below.</p>
+            <p>QC reports for the input reads are generated using <a href="https://www.bioinformatics.babraham.ac.uk/projects/fastqc/" target="_blank">FastQC</a> and summarized into a single report with <a href="https://multiqc.info/" target="_blank">MultiQC</a> A link to the MultiQC report is provided below.</p>
             <blockquote><strong>NOTE</strong>: FastQC was designed for QC of whole-genome shotgun NGS reads prior to genome asssembly. A QC warning or failure for some modules (such as per-base sequence content or sequence duplication levels) may or may not be a concern with MH reads. Interpret results with care!</blockquote>
-
-            {% if "r1readlen" in plots %}
-            <table>
-                <tr><th>Sample</th><th>R1 Report</th><th>R2 Report</th></tr>
-                {% for sample in samples %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td><a href="analysis/{{sample}}/fastqc/R1-fastqc.html" target="_blank">Click here to open in a new tab</a></td>
-                    <td><a href="analysis/{{sample}}/fastqc/R2-fastqc.html" target="_blank">Click here to open in a new tab</a></td>
-                </tr>
-                {% endfor %}
-            </table>
-            {% else %}
-            <table>
-                <tr><th>Sample</th><th>Report</th></tr>
-                {% for sample in samples %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td><a href="analysis/{{sample}}/fastqc/report.html" target="_blank">Click here to open in a new tab</a></td>
-                </tr>
-                {% endfor %}
-            </table>
-            {% endif %}
-
+            <p><a href="analysis/multiqc_report.html",  target="_blank">Click here to open MultiQC report in a new tab</a></p>
+        
             {% if read_length_table is none %}
                 {% if "r1readlen" in plots %}
                     <p>The following ridge plots show the distribution of R1 and R2 read lengths for each sample.</p>

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -16,14 +16,13 @@ from microhapulator import api as mhapi
 from microhapulator.pipeaux import full_reference_index_files
 from os import symlink
 
-preproc_aux_files = chain(
-    expand("analysis/{sample}/fastqc/R{end}-fastqc.html", sample=config["samples"], end=(1, 2)),
-    [
-        "analysis/r1-read-lengths.png",
-        "analysis/r2-read-lengths.png",
-        "analysis/merged-read-lengths.png",
-    ],
-)
+preproc_aux_files = [
+    "analysis/r1-read-lengths.png",
+    "analysis/r2-read-lengths.png",
+    "analysis/merged-read-lengths.png",
+    "analysis/multiqc_report.html",
+]
+
 
 summary_aux_files = (expand("analysis/{sample}/flash.log", sample=config["samples"]),)
 
@@ -42,6 +41,17 @@ rule fastqc:
             outfile = Path(outfile)
             linkfile = f"analysis/{wildcards.sample}/fastqc/R{end}-fastqc.html"
             symlink(outfile.name, linkfile)
+
+
+rule multiqc:
+    input:
+        expand("analysis/{sample}/fastqc/R{end}-fastqc.html", sample=config["samples"], end=(1, 2)),
+    output:
+        report="analysis/multiqc_report.html",
+    shell:
+        """
+        multiqc analysis/*/fastqc --outdir analysis
+        """
 
 
 rule merge:

--- a/microhapulator/workflows/preproc-single.smk
+++ b/microhapulator/workflows/preproc-single.smk
@@ -15,10 +15,8 @@ from microhapulator import api as mhapi
 from microhapulator.pipeaux import full_reference_index_files
 from os import symlink
 
-preproc_aux_files = chain(
-    expand("analysis/{sample}/fastqc/report.html", sample=config["samples"]),
-    ["analysis/read-lengths.png"],
-)
+preproc_aux_files = ["analysis/read-lengths.png", "analysis/multiqc_report.html"]
+
 
 summary_aux_files = list()
 
@@ -35,6 +33,17 @@ rule fastqc:
         outfile = Path(outfiles[0])
         linkfile = f"analysis/{wildcards.sample}/fastqc/report.html"
         symlink(outfile.name, linkfile)
+
+
+rule multiqc:
+    input:
+        expand("analysis/{sample}/fastqc/report.html", sample=config["samples"]),
+    output:
+        report="analysis/multiqc_report.html",
+    shell:
+        """
+        multiqc analysis/*/fastqc --outdir analysis
+        """
 
 
 rule fastq_reads:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "jsonschema>=4.0",
         "matplotlib>=3.0",
         "microhapdb>=0.10.1",
+        "multiqc>=1.14",
         "nbformat>=5.0,<5.6",
         "numpy>=1.19",
         "pandas>1.0",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "biopython",
         "happer>=0.1",
         "insilicoseq>=1.5.4,<2.0",
-        "importlib-metadata>=7.1.0",
         "jsonschema>=4.0",
         "matplotlib>=3.0",
         "microhapdb>=0.10.1",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "biopython",
         "happer>=0.1",
         "insilicoseq>=1.5.4,<2.0",
+        "importlib-metadata>=7.1.0",
         "jsonschema>=4.0",
         "matplotlib>=3.0",
         "microhapdb>=0.10.1",


### PR DESCRIPTION
This MR closes #160. Instead of providing links in the report to FastQC results for each sample, the report now contains a single link to a MultiQC plot with QC data for all samples. 

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
