### PR TITLE
Change typing rate table to account for reads mapped to multiple markers at the same locus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).
 - Bug with counting repetitive reads (#163).
+- Typing rate display in report (#174).
 
 
 ## [0.7.2] 2022-10-12

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -371,20 +371,22 @@
 
             <a name="typing"></a>
             <h2>Haplotype Calling</h2>
-            <p>Haplotypes are called empirically on a per-read basis using <code>mhpl8r type</code>. Reads that span all SNPs of interest in the corresponding marker are examined; all other reads are discarded. The haplotype tallies represent a <em>typing result</em> for each sample.</p>
+            <p>Haplotypes are called empirically on a per-read basis using <code>mhpl8r type</code>. Reads that span all SNPs of interest in the corresponding marker are examined; all other reads are discarded. If a read maps to multiple markers at the same locus, haplotypes are called for each marker at the locus; therefore, the number of typing events can exceed the number of mapped reads. The haplotype tallies represent a <em>typing result</em> for each sample.</p>
             <p class="title"><strong>Table 4.1</strong>: Read typing metrics.</p>
             <table>
                 <tr>
                     <th>Sample</th>
                     <th class="alnrt">Mapped Reads</th>
-                    <th class="alnrt">Typed Reads</th>
+                    <th class="alnrt">Attempted Typing Events</th>
+                    <th class="alnrt">Successful Typing Events</th>
                     <th class="alnrt">Typing Success Rate</th>
                 </tr>
                 {% for i, row in summary.iterrows() %}
                 <tr>
                     <td>{{row.Sample}}</td>
                     <td class="alnrt">{{ "{:,}".format(row.Mapped) }}</td>
-                    <td class="alnrt">{{ "{:,}".format(row.Typed) }}</td>
+                    <td class="alnrt">{{ "{:,}".format(row.TypedAttempted) }}</td>
+                    <td class="alnrt">{{ "{:,}".format(row.TypedSuccess) }}</td>
                     <td class="alnrt">{{ "{:.2f}".format(row.TypingRate * 100) }}%</td>
                 </tr>
                 {% endfor %}

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -371,7 +371,14 @@
 
             <a name="typing"></a>
             <h2>Haplotype Calling</h2>
-            <p>Haplotypes are called empirically on a per-read basis using <code>mhpl8r type</code>. Reads that span all SNPs of interest in the corresponding marker are examined; all other reads are discarded. If a read maps to multiple markers at the same locus, haplotypes are called for each marker at the locus; therefore, the number of typing events can exceed the number of mapped reads. The haplotype tallies represent a <em>typing result</em> for each sample.</p>
+            <p>Haplotypes are called empirically using <code>mhpl8r type</code>mhpl8r type as follows. MicroHapulator examines each
+                aligned read to determine its suitability for haplotype calling: this is a <em>typing event</em>. If the read
+                alignment spans all SNPs of interest, the typing event is successful and a haplotype call is made. If not, the
+                typing event is failed and no haplotype call is made. (<em>Note that if more than one marker is defined at a given
+                locus, MicroHapulator can attempt multiple typing events per read. In this case the number of <strong>Attempted Typing
+                Events </strong> will exceed the number of <strong>Mapped Reads.</strong></em>) Collectively, the tallies of each observed haplotype represent a
+                typing result for each sample. The typing rate is calculated as the number of successful typing events divided by
+                the total number of attempted typing events.</p>
             <p class="title"><strong>Table 4.1</strong>: Read typing metrics.</p>
             <table>
                 <tr>

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -264,13 +264,13 @@ def aggregate_summary(samples, reads_are_paired=True):
             frmaptotal == maptotal
         ), f"Sample={sample} fullrefr map total={frmaptotal} map total={maptotal}"
         typing = pd.read_csv(f"analysis/{sample}/{sample}-typing-rate.tsv", sep="\t")
-        num_typed_reads = typing.TypedReads.sum()
-        typing_total_reads = typing.TotalReads.sum()
+        num_typing_success = typing.TypedReads.sum()
+        num_typing_attempted = typing.TotalReads.sum()
         # At some point the following command was causing a failure. I've disabled the check for
         # now, but it's worth following up on to see what might cause this discrepancy.
         # -- Daniel Standage 2022-04-22
         # assert typing_total_reads == mapped, f"Sample={sample} type total={typing_total_reads} mapped={mapped}"
-        typing_rate = num_typed_reads / typing_total_reads
+        typing_rate = num_typing_success / num_typing_attempted
         chisq = parse_balance_stat(f"analysis/{sample}/{sample}-interlocus-balance-chisq.txt")
         tstat = parse_balance_stat(f"analysis/{sample}/{sample}-heterozygote-balance-pttest.txt")
         entry = [
@@ -284,7 +284,8 @@ def aggregate_summary(samples, reads_are_paired=True):
             mapped / maptotal,
             frmapped,
             frmapped / frmaptotal,
-            num_typed_reads,
+            num_typing_success,
+            num_typing_attempted,
             typing_rate,
             chisq,
             tstat,
@@ -301,7 +302,8 @@ def aggregate_summary(samples, reads_are_paired=True):
         "MappingRate",
         "MappedFullRefr",
         "MappingRateFullRefr",
-        "Typed",
+        "TypedSuccess",
+        "TypedAttempted",
         "TypingRate",
         "InterlocChiSq",
         "HetTstat",

--- a/microhapulator/tests/data/gbr-usc-summary.tsv
+++ b/microhapulator/tests/data/gbr-usc-summary.tsv
@@ -1,2 +1,2 @@
-Sample	TotalReads	Merged	MergeRate	LengthFailed	LengthPassed	Mapped	MappingRate	MappedFullRefr	MappingRateFullRefr	Typed	TypingRate	InterlocChiSq	HetTstat
-gbr-usc	5000	4954	0.9908	0	4954	4954	1.0000	4954	1.0000	4861	0.9812	0.0000	2.2802
+Sample	TotalReads	Merged	MergeRate	LengthFailed	LengthPassed	Mapped	MappingRate	MappedFullRefr	MappingRateFullRefr	TypedSuccess	TypedAttempted	TypingRate	InterlocChiSq	HetTstat
+gbr-usc	5000	4954	0.9908	0	4954	4954	1.0000	4954	1.0000	4861	4954	0.9812	0.0000	2.2802


### PR DESCRIPTION
This PR closes #171 .  Now that we allow multiple marker definitions at a given locus, reads are typed multiple times. This PR changes the table in the report to show `Attempted Typing Events` and `Successful Typing Events` where a "typing event" is defined as  haplotype calling for 1 read at a single marker definition. 

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
