### PR TITLE
HTML report sub templates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Replaced read QC donut plots with a stacked bar chart (#168).
     - Replaced FastQC report links with MultiQC link (#169).
     - Revised report text, added figure captions and table titles (#172).
+- GRCh38 coordinates are now mandatory in marker definitions (#176).
 
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,9 +44,8 @@ The list of SNP positions for a microhaplotype is its *marker definition*, and t
 The **Marker** column contains the identifier (name, label, or designator) of a microhaplotype in the panel, and the **Offset** column contains the distance of one SNP from the beginning of the reference sequence.
 For example, if a SNP of interest is the very first nucleotide in the reference, it has a distance of 0 from the beginning of the sequence and thus its offset is `0`.
 If a SNP is the 10th nucleotide, its offset is `9`.
-
 The **Chrom** and **OffsetHg38** columns indicate the position of each SNP in the GRCh38 reference human genome assembly.
-**While these two columns are not strictly required, certain quality control checks in the end-to-end MH analysis pipeline will be disabled if this data is absent.**
+**As of version MicroHapulator version 0.8, these two columns are now required.**
 
 The following command shows how to use MicroHapDB (version 0.8 or greater) to prepare a marker definition file.
 Note that it is identical to the previous command, except that the `--format=fasta` setting was changed to `--format=offsets`.

--- a/microhapulator/api.py
+++ b/microhapulator/api.py
@@ -751,8 +751,6 @@ def repetitive_mapping(marker_bam_file, fullref_bam_file, markertsv, minbasequal
     )
     marker_bam = pysam.AlignmentFile(marker_bam_file, "rb")
     microhaps = MicrohapIndex.from_files(markertsv)
-    if not microhaps.has_chrom_offsets:
-        raise ValueError("cannot perform repetitive analysis without chromosome offsets")
     reads_to_marker_fullref = get_reads_in_marker_loci(fullref_bam_file, microhaps)
     for locus, marker in microhaps:
         repetitive_count = count_repetitive_reads(

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -225,9 +225,6 @@ def validate_panel_config(markerseqs, markerdefn):
     print("[MicroHapulator] validating panel configuration", file=sys.stderr)
     index = MicrohapIndex.from_files(markerdefn, markerseqs)
     index.validate()
-    if not index.has_chrom_offsets:
-        msg = "Chrom and/or OffsetHg38 columns missing from the marker definition, repetitive read alignment analysis will not be performed"
-        warn(msg)
 
 
 def main(args):

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -94,16 +94,9 @@
                 Report generated at {{date}},<br />
                 using <a href="https://microhapulator.readthedocs.io" target="_blank">MicroHapulator</a> version {{mhpl8rversion}}.
             </p>
-
             <h2>Table of Contents</h2>
-            <ol>
-                <li><a href="#readqc">Read QA/QC</a></li>
-                {% if "r1readlen" in plots %}
-                <li><a href="#readmerging">Read Merging</a></li>
-                {% endif %}
-                <li><a href="#readmapping">Read Mapping</a></li>
-                <li><a href="#typing">Haplotype Calling</a></li>
-                <li><a href="#filters">Genotype Calling</a></li>
+                {% block table_of_contents %}
+                {% endblock %}
             </ol>
             <p>
                 A summary of the statistics presented in this report is aggregated in a single table available at <code>analysis/summary.tsv</code> in the working directory.
@@ -126,187 +119,23 @@
             <p><a href="analysis/multiqc_report.html",  target="_blank">Click here to open MultiQC report in a new tab</a></p>
 
             {% if read_length_table is none %}
-                {% if "r1readlen" in plots %}
-                    <img src="analysis/r1-read-lengths.png" />
-                    <img src="analysis/r2-read-lengths.png" />
-                    <p class="caption"><strong>Figure 1.1</strong>: Ridge plots showing the length distribution of input R1 (left) and R2 (right) reads.</p>
-                {% else %}
-                    <img class="center" src="analysis/read-lengths.png" />
-                    <p class="caption"><strong>Figure 1.1</strong>: Ridge plot showing the length distribution of input reads.</p>
-                {% endif %}
+                {% block read_len_plots %}
+                {% endblock %}
             {% else %}
-                {% if "r1readlen" in plots %}
-                <p class="title"><strong>Table 1.1</strong>: Uniform read lengths for each sample.</p>
-                <table class="half">
-                    <tr>
-                        <th>Sample</th>
-                        <th class="alnrt">Length R1</th>
-                        <th class="alnrt">Length R2</th>
-                    </tr>
-                    {% for i, row in read_length_table.iterrows() %}
-                    <tr>
-                        <td>{{ row.Sample }}</td>
-                        <td class="alnrt">{{ row.LengthR1 }}</td>
-                        <td class="alnrt">{{ row.LengthR2 }}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
-                {% else %}
-                <p class="title"><strong>Table 1.1</strong>: Uniform read length for each sample.</p>
-                <table class="half">
-                    <tr>
-                        <th>Sample</th>
-                        <th class="alnrt">Length</th>
-                    </tr>
-                    {% for i, row in read_length_table.iterrows() %}
-                    <tr>
-                        <td>{{ row.Sample }}</td>
-                        <td class="alnrt">{{ row.Length }}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
-                {% endif %}
+                {% block read_len_table%}
+                {% endblock %}
             {% endif %}
 
-            {% if reads_are_paired %}
-            <p>
-                Prior to subsequent analysis, reads are filtered for ambiguous sequence content.
-                Any read comprised of more than {{"{:.0f}".format(ambiguous_read_threshold * 100)}}% ambiguous bases (<code>N</code>) is discarded, along with its mate.
-                (This threshold can be configured with the <code>--ambiguous-thresh</code> argument.)
-                The table below shows the number of read pairs that were removed from each sample and which read(s) in the pair exceeded the filtering threshold.
-            </p>
-            <p class="title"><strong>Table 1.2</strong>: Metrics for read filtering based on ambiguous content.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Total Pairs</th>
-                    <th class="alnrt">R1 Only Failed</th>
-                    <th class="alnrt">R2 Only Failed</th>
-                    <th class="alnrt">Pair Failed</th>
-                    <th class="alnrt">Pairs Removed</th>
-                    <th class="alnrt">Pairs Kept</th>
-                    <th class="alnrt">Retention</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.ambig.total_reads}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded_r1}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded_r2}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded_both}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded}}</td>
-                    <td class="alnrt">{{stats.ambig.retained}}</td>
-                    <td class="alnrt">{{stats.ambig.retention_rate}}</td>
-                </tr>
-                {% endfor %}
-            </table>
-            {% else %}
-            <p>
-                Prior to subsequent analysis, reads are filtered for length and ambiguous sequence content.
-                Any read comprised of more than {{"{:.0f}".format(ambiguous_read_threshold * 100)}}% ambiguous bases (<code>N</code>) is discarded.
-                Reads less than {{"{:,}".format(read_length_threshold)}} bp in length are also excluded from all subsequent analysis.
-                (These thresholds can be configured with the <code>--ambiguous-thresh</code> and <code>--length-thresh</code> arguments.)
-            </p>
-            <p class="title"><strong>Table 1.2</strong>: Read filtering metrics.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Total Reads</th>
-                    <th class="alnrt">Filtered (Ambiguous)</th>
-                    <th class="alnrt">Filtered (Length)</th>
-                    <th class="alnrt">Reads Kept</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.total_reads}}</td>
-                    <td class="alnrt">{{stats.filtered_ambig}}</td>
-                    <td class="alnrt">{{stats.filtered_length}}</td>
-                    <td class="alnrt">{{stats.retention}}</td>
-                </tr>
-                {% endfor%}
-            </table>
-            {% endif %}
+            {% block filter_stats %}
+            {% endblock %}
 
-            {% if "r1readlen" in plots %}
-            <a name="readmerging"></a>
-            <h2>Read Merging</h2>
-            <p>
-                Paired end reads are merged using <a href="https://ccb.jhu.edu/software/FLASH/" target="_blank">FLASh</a>.
-                Merged reads less than {{"{:,}".format(read_length_threshold)}} bp in length are filtered out prior to read mapping and excluded from all subsequent analysis.
-                (This threshold can be configured with the <code>--length-thresh</code> argument.)
-            </p>
-            <p class="title"><strong>Table 2.1</strong>: Read merging metrics.</p>
-            <table class="half">
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Filtered Reads</th>
-                    <th class="alnrt">Merged Reads</th>
-                    <th class="alnrt">Merge Rate</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.merge.total_reads}}</td>
-                    <td class="alnrt">{{stats.merge.merged_reads}}</td>
-                    <td class="alnrt">{{stats.merge.merge_rate}}</td>
-                </tr>
-                {% endfor %}
-            </table>
-            <img class="center" src="analysis/merged-read-lengths.png" />
-            <p class="caption"><strong>Figure 2.2</strong>: Ridge plot showing the length distribution of merged reads.</p>
-
-            <p class="title"><strong>Table 2.3</strong>: Metrics for read length filtering.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Total Merged Reads</th>
-                    <th class="alnrt">Reads Removed</th>
-                    <th class="alnrt">Reads Kept</th>
-                    <th class="alnrt">Retention</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.length.total_reads}}</td>
-                    <td class="alnrt">{{stats.length.excluded}}</td>
-                    <td class="alnrt">{{stats.length.kept}}</td>
-                    <td class="alnrt">{{stats.length.retention_rate}}</td>
-                </tr>
-            {% endfor%}
-            </table>
-            {% endif %}
+            {% block merge_stats %}
+            {% endblock %}
 
             <a name="readmapping"></a>
             <h2>Read Mapping</h2>
-            <p>Filtered {% if reads_are_paired %} and merged {% endif %} reads are aligned to marker reference sequences using <a href="http://bio-bwa.sourceforge.net/bwa.shtml" target="_blank">BWA MEM</a> and formatted, sorted, and indexed using <a href="http://www.htslib.org/" target="_blank">SAMtools</a>.</p>
-            <p class="title"><strong>Table 3.1</strong>: Read mapping metrics.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    {% if "r1readlen" in plots %}
-                    <th class="alnrt">Merged Reads</th>
-                    {% else %}
-                    <th class="alnrt">Filtered Reads</th>
-                    {% endif %}
-                    <th class="alnrt">Mapped Reads</th>
-                    <th class="alnrt">Mapping Rate</th>
-                    <th class="alnrt">Chi-square</th>
-                </tr>
-                {% for i, row in summary.iterrows() %}
-                <tr>
-                    <td>{{row.Sample}}</td>
-                    {% if "r1readlen" in plots %}
-                    <td class="alnrt">{{ "{:,}".format(row.Merged) }}</td>
-                    {% else %}
-                    <td class="alnrt">{{ "{:,}".format(row.TotalReads) }}</td>
-                    {% endif %}
-                    <td class="alnrt">{{ "{:,}".format(row.Mapped) }}</td>
-                    <td class="alnrt">{{ "{:.2f}".format(row.MappingRate * 100) }}%</td>
-                    <td class="alnrt">{{ "{:.2f}".format(row.InterlocChiSq)}}</td>
-                </tr>
-                {% endfor %}
-            </table>
+            {% block read_map_stats %}
+            {% endblock %}
             <br />
             <p>
                 The reported chi-square statistic is a measure of read coverage imbalance between markers, and can be compared among samples sequenced using the sample panel:

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -350,12 +350,8 @@
                         <tr>
                             <td><a href="marker-detail-report.html?marker={{markername}}" target="_blank">{{markername}}</a></td>
                             {% for sample_data in mapping_rates.values()%}
-                            <td class="alnrt" data-sortvalue={{sample_data.loc[markername, 'ReadCount']}}>{{"{:,d}".format(sample_data.loc[markername, 'ReadCount'])}}</td>
-                            {% if isna(sample_data.loc[markername, 'RepetitiveReads']) %}
-                            <td class="alnrt" data-sortvalue="0">N/A</td>
-                            {% else %}
+                            <td class="alnrt" data-sortvalue="{{sample_data.loc[markername, 'ReadCount']}}">{{"{:,d}".format(sample_data.loc[markername, 'ReadCount'])}}</td>
                             <td class="alnrt" data-sortvalue="{{sample_data.loc[markername, 'RepetitiveReads']}}">{{"{:,d}".format(sample_data.loc[markername, 'RepetitiveReads'])}}</td>
-                            {% endif %}
                             {% endfor %}
                         </tr>
                         {% endfor %}

--- a/microhapulator/marker.py
+++ b/microhapulator/marker.py
@@ -76,7 +76,7 @@ class MicrohapIndex:
 
     @staticmethod
     def chromosome_offsets(rowgroup):
-        if rowgroup.OffsetHg38.isnull.any():
+        if rowgroup.OffsetHg38.isnull().any():
             markerid = rowgroup.Marker.iloc[0]
             message = f"incomplete marker definition for {markerid}, includes null values"
             raise ValueError(message)

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -104,9 +104,7 @@ def marker_details():
     for locus, marker in index:
         marker_offsets = ", ".join([str(o) for o in sorted(marker.offsets_locus)])
         chrom = marker.chrom
-        offsets38 = "N/A"
-        if index.has_chrom_offsets:
-            offsets38 = ", ".join([str(o) for o in sorted(marker.offsets_chrom)])
+        offsets38 = ", ".join([str(o) for o in sorted(marker.offsets_chrom)])
         seq = locus.sequence.strip().upper()
         gc_content = round((seq.count("G") + seq.count("C")) / len(seq) * 100, 2)
         sample_details = [

--- a/microhapulator/tests/data/prof/srm.json
+++ b/microhapulator/tests/data/prof/srm.json
@@ -1,0 +1,19 @@
+{
+    "markers": {
+        "mh05KK-170.v1": {
+            "genotype": [],
+            "max_coverage": 4113,
+            "mean_coverage": 4111.9,
+            "min_coverage": 4092,
+            "num_discarded_reads": 6,
+            "typing_result": {
+                "C,A,G,A": 2317,
+                "C,G,G,A": 1789,
+                "C,T,G,A": 9
+            }
+        }
+    },
+    "ploidy": null,
+    "type": "TypingResult",
+    "version": "0.7.2+46.gdda0797.dirty"
+}

--- a/microhapulator/tests/test_marker.py
+++ b/microhapulator/tests/test_marker.py
@@ -53,11 +53,8 @@ def test_load_marker_definitions_missing_column():
 
 def test_load_marker_definitions_minimal():
     defn_file = data_file("def/default-panel-offsets-minimal.tsv")
-    microhaps = MicrohapIndex.from_files(defn_file)
-    markers = [marker for locus, marker in microhaps]
-    assert len(markers) == 22
-    assert markers[0].offsets_chrom is None
-    assert microhaps.has_chrom_offsets is False
+    with pytest.raises(ValueError, match="missing from marker definition file: Chrom, OffsetHg3"):
+        MicrohapIndex.from_files(defn_file)
 
 
 @pytest.mark.parametrize(

--- a/microhapulator/tests/test_type.py
+++ b/microhapulator/tests/test_type.py
@@ -147,21 +147,22 @@ def test_type_cli_simple(tmp_path):
     }
 
 
-def test_type_filter_threshold():
-    bam = data_file("bam/dyncut-test-reads.bam")
-    tsv = data_file("def/dyncut-panel.tsv")
-    rslt = mhapi.type(bam, tsv)
-    thresholds = load_marker_thresholds(rslt.markers(), global_static=10, global_dynamic=0.005)
-    rslt.filter(thresholds)
-    assert rslt.haplotypes("MHDBL000018") == set(["C,A,C,T,G", "T,G,C,T,G"])
-    assert rslt.haplotypes("MHDBL000156") == set(["T,C,A,C", "T,C,G,G"])
-    rslt = mhapi.type(bam, tsv)
-    thresholds = load_marker_thresholds(rslt.markers(), global_static=4, global_dynamic=0.005)
-    rslt.filter(thresholds)
-    assert rslt.haplotypes("MHDBL000018") == set(
-        ["C,A,C,T,G", "T,G,C,T,G", "C,A,C,T,A", "T,G,C,T,A"]
+@pytest.mark.parametrize(
+    "static,dynamic,genotype",
+    [
+        (5, 0.00005, {"C,A,G,A", "C,G,G,A", "C,T,G,A"}),
+        (10, 0.00005, {"C,A,G,A", "C,G,G,A"}),
+        (5, 0.02, {"C,A,G,A", "C,G,G,A"}),
+        (2000, 0.02, {"C,A,G,A"}),
+    ],
+)
+def test_type_filter_threshold(static, dynamic, genotype):
+    result = TypingResult(fromfile=data_file("prof/srm.json"))
+    thresholds = load_marker_thresholds(
+        result.markers(), global_static=static, global_dynamic=dynamic
     )
-    assert rslt.haplotypes("MHDBL000156") == set(["T,C,A,C", "T,C,G,G"])
+    result.filter(thresholds)
+    assert result.haplotypes("mh05KK-170.v1") == genotype
 
 
 def test_type_no_var_offsets():

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -270,12 +270,10 @@ rule repetitive_mapping:
         marker_def="marker-definitions.tsv",
     output:
         counts="analysis/{sample}/{sample}-repetitive-reads.csv",
-    run:
-        microhaps = MicrohapIndex.from_files(input.marker_def)
-        if microhaps.has_chrom_offsets:
-            shell("mhpl8r repetitive {input} --out {output}")
-        else:
-            shell("touch {output}")
+    shell:
+        """
+        mhpl8r repetitive {input} --out {output}
+        """
 
 
 rule read_mapping_qc:


### PR DESCRIPTION
This MR cleans up the code to generate the HTML report by creating different `jinja2` templates for paired end and single end reads. `template.html` is the base template and `paired.html` and `single.html` are new child templates that inherit `template.html`. These two child templates handle the elements of the report that are unique to paired and single end reads respectively. The report elements common to both data types are handled in `template.html`.

----------

- [x] Changes are clearly described above
- ~Any relevant issue threads are referenced in the description~
- ~ Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)~
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [ ] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
