### PR TITLE
HTML report sub templates attempt 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Revised report text, added figure captions and table titles (#172).
     - Streamlined the Python code responsible for generating the report (#175, #177).
 - GRCh38 coordinates are now mandatory in marker definitions (#176).
+- Jijna2 sub-templates added to handle differences in the report for single ended versus paired end reads (#179). 
 
 ### Fixed
 - Bug with inconsistent sorting of read counts for interlocus balance (#159).

--- a/microhapulator/data/paired.html
+++ b/microhapulator/data/paired.html
@@ -1,0 +1,119 @@
+{% extends "template.html" %}
+{% block table_of_contents %}
+<li><a href="#readqc">Read QA/QC</a></li>
+<li><a href="#readmerging">Read Merging</a></li>
+<li><a href="#readmapping">Read Mapping</a></li>
+<li><a href="#typing">Haplotype Calling</a></li>
+<li><a href="#filters">Genotype Calling</a></li>
+{% endblock %}
+
+{% block read_len_fig %}
+<img src="analysis/r1-read-lengths.png" />
+<img src="analysis/r2-read-lengths.png" />
+<p class="caption"><strong>Figure 1.1</strong>: Ridge plots showing the length distribution of input R1 (left) and R2 (right) reads.</p>
+{% endblock %}
+
+{% block read_len_table %}
+<p class="title"><strong>Table 1.1</strong>: Uniform read lengths for each sample.</p>
+<table class="half">
+    <tr>
+        <th>Sample</th>
+        <th class="alnrt">Length R1</th>
+        <th class="alnrt">Length R2</th>
+    </tr>
+    {% for i, row in read_length_table.iterrows() %}
+    <tr>
+        <td>{{ row.Sample }}</td>
+        <td class="alnrt">{{ row.LengthR1 }}</td>
+        <td class="alnrt">{{ row.LengthR2 }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}
+
+{% block read_filter_stats %}
+<p>
+    Prior to subsequent analysis, reads are filtered for ambiguous sequence content.
+    Any read comprised of more than {{"{:.0f}".format(ambiguous_read_threshold * 100)}}% ambiguous bases (<code>N</code>) is discarded, along with its mate.
+    (This threshold can be configured with the <code>--ambiguous-thresh</code> argument.)
+    The table below shows the number of read pairs that were removed from each sample and which read(s) in the pair exceeded the filtering threshold.
+</p>
+<p class="title"><strong>Table 1.2</strong>: Metrics for read filtering based on ambiguous content.</p>
+<table>
+    <tr>
+        <th>Sample</th>
+        <th class="alnrt">Total Pairs</th>
+        <th class="alnrt">R1 Only Failed</th>
+        <th class="alnrt">R2 Only Failed</th>
+        <th class="alnrt">Pair Failed</th>
+        <th class="alnrt">Pairs Removed</th>
+        <th class="alnrt">Pairs Kept</th>
+        <th class="alnrt">Retention</th>
+    </tr>
+    {% for sample, stats in qc.items() %}
+    <tr>
+        <td>{{sample}}</td>
+        <td class="alnrt">{{stats.ambig.total_reads}}</td>
+        <td class="alnrt">{{stats.ambig.excluded_r1}}</td>
+        <td class="alnrt">{{stats.ambig.excluded_r2}}</td>
+        <td class="alnrt">{{stats.ambig.excluded_both}}</td>
+        <td class="alnrt">{{stats.ambig.excluded}}</td>
+        <td class="alnrt">{{stats.ambig.retained}}</td>
+        <td class="alnrt">{{stats.ambig.retention_rate}}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}
+
+{% block read_merge_stats %}
+<a name="readmerging"></a>
+<h2>Read Merging</h2>
+<p>
+    Paired end reads are merged using <a href="https://ccb.jhu.edu/software/FLASH/" target="_blank">FLASh</a>.
+    Merged reads less than {{"{:,}".format(read_length_threshold)}} bp in length are filtered out prior to read mapping and excluded from all subsequent analysis.
+    (This threshold can be configured with the <code>--length-thresh</code> argument.)
+</p>
+<p class="title"><strong>Table 2.1</strong>: Read merging metrics.</p>
+<table class="half">
+    <tr>
+        <th>Sample</th>
+        <th class="alnrt">Filtered Reads</th>
+        <th class="alnrt">Merged Reads</th>
+        <th class="alnrt">Merge Rate</th>
+    </tr>
+    {% for sample, stats in qc.items() %}
+    <tr>
+        <td>{{sample}}</td>
+        <td class="alnrt">{{stats.merge.total_reads}}</td>
+        <td class="alnrt">{{stats.merge.merged_reads}}</td>
+        <td class="alnrt">{{stats.merge.merge_rate}}</td>
+    </tr>
+    {% endfor %}
+</table>
+<img class="center" src="analysis/merged-read-lengths.png" />
+<p class="caption"><strong>Figure 2.2</strong>: Ridge plot showing the length distribution of merged reads.</p>
+
+<p class="title"><strong>Table 2.3</strong>: Metrics for read length filtering.</p>
+<table>
+    <tr>
+        <th>Sample</th>
+        <th class="alnrt">Total Merged Reads</th>
+        <th class="alnrt">Reads Removed</th>
+        <th class="alnrt">Reads Kept</th>
+        <th class="alnrt">Retention</th>
+    </tr>
+    {% for sample, stats in qc.items() %}
+    <tr>
+        <td>{{sample}}</td>
+        <td class="alnrt">{{stats.length.total_reads}}</td>
+        <td class="alnrt">{{stats.length.excluded}}</td>
+        <td class="alnrt">{{stats.length.kept}}</td>
+        <td class="alnrt">{{stats.length.retention_rate}}</td>
+    </tr>
+{% endfor %}
+</table>
+{% endblock %}
+
+{% block read_map_header %}
+<p>Filtered and merged reads are aligned to marker reference sequences using <a href="http://bio-bwa.sourceforge.net/bwa.shtml" target="_blank">BWA MEM</a> and formatted, sorted, and indexed using <a href="http://www.htslib.org/" target="_blank">SAMtools</a>.</p>
+{% endblock %}

--- a/microhapulator/data/single.html
+++ b/microhapulator/data/single.html
@@ -1,0 +1,62 @@
+{% extends "template.html" %}
+{% block table_of_contents %}
+<li><a href="#readqc">Read QA/QC</a></li>
+<li><a href="#readmapping">Read Mapping</a></li>
+<li><a href="#typing">Haplotype Calling</a></li>
+<li><a href="#filters">Genotype Calling</a></li>
+{% endblock %}
+
+{% block read_len_fig %}
+<img class="center" src="analysis/read-lengths.png" />
+<p class="caption"><strong>Figure 1.1</strong>: Ridge plot showing the length distribution of input reads.</p>
+{% endblock %}
+
+{% block read_len_table %}
+<p class="title"><strong>Table 1.1</strong>: Uniform read length for each sample.</p>
+<table class="half">
+    <tr>
+        <th>Sample</th>
+        <th class="alnrt">Length</th>
+    </tr>
+    {% for i, row in read_length_table.iterrows() %}
+    <tr>
+        <td>{{ row.Sample }}</td>
+        <td class="alnrt">{{ row.Length }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}
+
+{% block read_filter_stats %}
+<p>
+    Prior to subsequent analysis, reads are filtered for length and ambiguous sequence content.
+    Any read comprised of more than {{"{:.0f}".format(ambiguous_read_threshold * 100)}}% ambiguous bases (<code>N</code>) is discarded.
+    Reads less than {{"{:,}".format(read_length_threshold)}} bp in length are also excluded from all subsequent analysis.
+    (These thresholds can be configured with the <code>--ambiguous-thresh</code> and <code>--length-thresh</code> arguments.)
+</p>
+<p class="title"><strong>Table 1.2</strong>: Read filtering metrics.</p>
+<table>
+    <tr>
+        <th>Sample</th>
+        <th class="alnrt">Total Reads</th>
+        <th class="alnrt">Filtered (Ambiguous)</th>
+        <th class="alnrt">Filtered (Length)</th>
+        <th class="alnrt">Reads Kept</th>
+    </tr>
+    {% for sample, stats in qc.items() %}
+    <tr>
+        <td>{{sample}}</td>
+        <td class="alnrt">{{stats.total_reads}}</td>
+        <td class="alnrt">{{stats.filtered_ambig}}</td>
+        <td class="alnrt">{{stats.filtered_length}}</td>
+        <td class="alnrt">{{stats.retention}}</td>
+    </tr>
+    {% endfor%}
+</table>
+{% endblock %}
+
+{% block read_map_header %}
+<p>Filtered reads are aligned to marker reference sequences using <a href="http://bio-bwa.sourceforge.net/bwa.shtml"
+        target="_blank">BWA MEM</a> and formatted, sorted, and indexed using <a href="http://www.htslib.org/"
+        target="_blank">SAMtools</a>.</p>
+{% endblock %}

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -97,13 +97,9 @@
 
             <h2>Table of Contents</h2>
             <ol>
-                <li><a href="#readqc">Read QA/QC</a></li>
-                {% if reads_are_paired %}
-                <li><a href="#readmerging">Read Merging</a></li>
-                {% endif %}
-                <li><a href="#readmapping">Read Mapping</a></li>
-                <li><a href="#typing">Haplotype Calling</a></li>
-                <li><a href="#filters">Genotype Calling</a></li>
+                {% block table_of_contents %}
+                {% endblock %}
+
             </ol>
             <p>
                 A summary of the statistics presented in this report is aggregated in a single table available at <code>analysis/summary.tsv</code> in the working directory.
@@ -126,160 +122,23 @@
             <p><a href="analysis/multiqc_report.html",  target="_blank">Click here to open MultiQC report in a new tab</a></p>
 
             {% if read_length_table is none %}
-                {% if reads_are_paired %}
-                    <img src="analysis/r1-read-lengths.png" />
-                    <img src="analysis/r2-read-lengths.png" />
-                    <p class="caption"><strong>Figure 1.1</strong>: Ridge plots showing the length distribution of input R1 (left) and R2 (right) reads.</p>
-                {% else %}
-                    <img class="center" src="analysis/read-lengths.png" />
-                    <p class="caption"><strong>Figure 1.1</strong>: Ridge plot showing the length distribution of input reads.</p>
-                {% endif %}
+                {% block read_len_fig %}
+                {% endblock %}
             {% else %}
-                {% if reads_are_paired %}
-                <p class="title"><strong>Table 1.1</strong>: Uniform read lengths for each sample.</p>
-                <table class="half">
-                    <tr>
-                        <th>Sample</th>
-                        <th class="alnrt">Length R1</th>
-                        <th class="alnrt">Length R2</th>
-                    </tr>
-                    {% for i, row in read_length_table.iterrows() %}
-                    <tr>
-                        <td>{{ row.Sample }}</td>
-                        <td class="alnrt">{{ row.LengthR1 }}</td>
-                        <td class="alnrt">{{ row.LengthR2 }}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
-                {% else %}
-                <p class="title"><strong>Table 1.1</strong>: Uniform read length for each sample.</p>
-                <table class="half">
-                    <tr>
-                        <th>Sample</th>
-                        <th class="alnrt">Length</th>
-                    </tr>
-                    {% for i, row in read_length_table.iterrows() %}
-                    <tr>
-                        <td>{{ row.Sample }}</td>
-                        <td class="alnrt">{{ row.Length }}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
-                {% endif %}
+                {% block read_len_table %}
+                {% endblock %}
             {% endif %}
 
-            {% if reads_are_paired %}
-            <p>
-                Prior to subsequent analysis, reads are filtered for ambiguous sequence content.
-                Any read comprised of more than {{"{:.0f}".format(ambiguous_read_threshold * 100)}}% ambiguous bases (<code>N</code>) is discarded, along with its mate.
-                (This threshold can be configured with the <code>--ambiguous-thresh</code> argument.)
-                The table below shows the number of read pairs that were removed from each sample and which read(s) in the pair exceeded the filtering threshold.
-            </p>
-            <p class="title"><strong>Table 1.2</strong>: Metrics for read filtering based on ambiguous content.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Total Pairs</th>
-                    <th class="alnrt">R1 Only Failed</th>
-                    <th class="alnrt">R2 Only Failed</th>
-                    <th class="alnrt">Pair Failed</th>
-                    <th class="alnrt">Pairs Removed</th>
-                    <th class="alnrt">Pairs Kept</th>
-                    <th class="alnrt">Retention</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.ambig.total_reads}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded_r1}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded_r2}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded_both}}</td>
-                    <td class="alnrt">{{stats.ambig.excluded}}</td>
-                    <td class="alnrt">{{stats.ambig.retained}}</td>
-                    <td class="alnrt">{{stats.ambig.retention_rate}}</td>
-                </tr>
-                {% endfor %}
-            </table>
-            {% else %}
-            <p>
-                Prior to subsequent analysis, reads are filtered for length and ambiguous sequence content.
-                Any read comprised of more than {{"{:.0f}".format(ambiguous_read_threshold * 100)}}% ambiguous bases (<code>N</code>) is discarded.
-                Reads less than {{"{:,}".format(read_length_threshold)}} bp in length are also excluded from all subsequent analysis.
-                (These thresholds can be configured with the <code>--ambiguous-thresh</code> and <code>--length-thresh</code> arguments.)
-            </p>
-            <p class="title"><strong>Table 1.2</strong>: Read filtering metrics.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Total Reads</th>
-                    <th class="alnrt">Filtered (Ambiguous)</th>
-                    <th class="alnrt">Filtered (Length)</th>
-                    <th class="alnrt">Reads Kept</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.total_reads}}</td>
-                    <td class="alnrt">{{stats.filtered_ambig}}</td>
-                    <td class="alnrt">{{stats.filtered_length}}</td>
-                    <td class="alnrt">{{stats.retention}}</td>
-                </tr>
-                {% endfor%}
-            </table>
-            {% endif %}
+            {% block read_filter_stats %}
+            {% endblock %}
 
-            {% if reads_are_paired %}
-            <a name="readmerging"></a>
-            <h2>Read Merging</h2>
-            <p>
-                Paired end reads are merged using <a href="https://ccb.jhu.edu/software/FLASH/" target="_blank">FLASh</a>.
-                Merged reads less than {{"{:,}".format(read_length_threshold)}} bp in length are filtered out prior to read mapping and excluded from all subsequent analysis.
-                (This threshold can be configured with the <code>--length-thresh</code> argument.)
-            </p>
-            <p class="title"><strong>Table 2.1</strong>: Read merging metrics.</p>
-            <table class="half">
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Filtered Reads</th>
-                    <th class="alnrt">Merged Reads</th>
-                    <th class="alnrt">Merge Rate</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.merge.total_reads}}</td>
-                    <td class="alnrt">{{stats.merge.merged_reads}}</td>
-                    <td class="alnrt">{{stats.merge.merge_rate}}</td>
-                </tr>
-                {% endfor %}
-            </table>
-            <img class="center" src="analysis/merged-read-lengths.png" />
-            <p class="caption"><strong>Figure 2.2</strong>: Ridge plot showing the length distribution of merged reads.</p>
-
-            <p class="title"><strong>Table 2.3</strong>: Metrics for read length filtering.</p>
-            <table>
-                <tr>
-                    <th>Sample</th>
-                    <th class="alnrt">Total Merged Reads</th>
-                    <th class="alnrt">Reads Removed</th>
-                    <th class="alnrt">Reads Kept</th>
-                    <th class="alnrt">Retention</th>
-                </tr>
-                {% for sample, stats in qc.items() %}
-                <tr>
-                    <td>{{sample}}</td>
-                    <td class="alnrt">{{stats.length.total_reads}}</td>
-                    <td class="alnrt">{{stats.length.excluded}}</td>
-                    <td class="alnrt">{{stats.length.kept}}</td>
-                    <td class="alnrt">{{stats.length.retention_rate}}</td>
-                </tr>
-            {% endfor%}
-            </table>
-            {% endif %}
+            {% block read_merge_stats %}
+            {% endblock %}
 
             <a name="readmapping"></a>
             <h2>Read Mapping</h2>
-            <p>Filtered {% if reads_are_paired %} and merged {% endif %} reads are aligned to marker reference sequences using <a href="http://bio-bwa.sourceforge.net/bwa.shtml" target="_blank">BWA MEM</a> and formatted, sorted, and indexed using <a href="http://www.htslib.org/" target="_blank">SAMtools</a>.</p>
+            {% block read_map_header %}
+            {% endblock %}
             <p class="title"><strong>Table 3.1</strong>: Read mapping metrics.</p>
             <table>
                 <tr>

--- a/microhapulator/pipeaux.py
+++ b/microhapulator/pipeaux.py
@@ -13,7 +13,7 @@
 from .mapstats import MappingSummary, MappingStats
 from .qcsummary import PairedReadQCSummary, SingleEndReadQCSummary
 from datetime import datetime
-from jinja2 import Template
+from jinja2 import FileSystemLoader, Environment, Template
 import json
 import microhapulator
 import pandas as pd
@@ -145,9 +145,14 @@ def final_html_report(
     mapping_rates, marker_names = per_marker_mapping_rate(samples)
     thresholds = load_marker_thresholds(marker_names, thresh_file, thresh_static, thresh_dynamic)
     thresholds.fillna(0, inplace=True)
-    templatefile = resource_filename("microhapulator", "data/template.html")
-    with open(templatefile, "r") as infh, open("report.html", "w") as outfh:
-        template = Template(infh.read())
+    template_loader = FileSystemLoader(resource_filename("microhapulator", "data"))
+    env = Environment(loader=template_loader)
+    if reads_are_paired:
+        template_file = "paired.html"
+    else:
+        template_file = "single.html"
+    template = env.get_template(template_file)
+    with open("report.html", "w") as outfh:
         output = template.render(
             date=datetime.now().replace(microsecond=0).isoformat(),
             mhpl8rversion=microhapulator.__version__,


### PR DESCRIPTION
This MR cleans up the code to generate the HTML report by creating different `jinja2` templates for paired end and single end reads. `template.html` is the base template and `paired.html` and `single.html` are new child templates that inherit `template.html`. These two child templates handle the elements of the report that are unique to paired and single end reads respectively. The report elements common to both data types are handled in `template.html`. Note this PR has the same objective as PR #178 (now closed) but I accidentally branched off of a branch besides master and the number of merge conflicts that needed resolving was unwieldy so I started over.


- [x] Changes are clearly described above
- ~Any relevant issue threads are referenced in the description~
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
