### PR TITLE
Replace BWA MEM with Minimap2

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -22,10 +22,15 @@ jobs:
         curl -L -O http://ccb.jhu.edu/software/FLASH/FLASH-1.2.11-Linux-x86_64.tar.gz && tar -xzf FLASH-1.2.11-Linux-x86_64.tar.gz && sudo cp FLASH-1.2.11-Linux-x86_64/flash /usr/local/bin/ && rm -r FLASH-1.2.11*
         python -m pip install --upgrade pip
         pip install .
-        mv microhapulator mhpl8r_src
         mhpl8r getrefr
         make devdeps
     - name: Test with pytest
-      run: make test
+      run: |
+        # Move the source code so the tests run on the *installed* code (which is where the
+        # reference genome index is placed) rather than the source code
+        mv microhapulator mhpl8r_src
+        make test
+        # Move the code back for style check
+        mv mhpl8r_src microhapulator
     - name: Style check
       run: make style

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -22,6 +22,7 @@ jobs:
         curl -L -O http://ccb.jhu.edu/software/FLASH/FLASH-1.2.11-Linux-x86_64.tar.gz && tar -xzf FLASH-1.2.11-Linux-x86_64.tar.gz && sudo cp FLASH-1.2.11-Linux-x86_64/flash /usr/local/bin/ && rm -r FLASH-1.2.11*
         python -m pip install --upgrade pip
         pip install .
+        mv microhapulator mhpl8r_src
         mhpl8r getrefr
         make devdeps
     - name: Test with pytest

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,12 +18,12 @@ jobs:
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install bwa samtools fastqc
+        sudo apt-get install minimap2 samtools fastqc
         curl -L -O http://ccb.jhu.edu/software/FLASH/FLASH-1.2.11-Linux-x86_64.tar.gz && tar -xzf FLASH-1.2.11-Linux-x86_64.tar.gz && sudo cp FLASH-1.2.11-Linux-x86_64/flash /usr/local/bin/ && rm -r FLASH-1.2.11*
         python -m pip install --upgrade pip
         pip install .
+        mhpl8r getrefr
         make devdeps
-        curl -L https://osf.io/wuzm6/download --output bwa_index.tar.gz && tar -xzf bwa_index.tar.gz && cp bwa_index/* /home/runner/work/MicroHapulator/MicroHapulator/microhapulator/data/ && rm -r bwa_index*
     - name: Test with pytest
       run: make test
     - name: Style check

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 microhapulator/data/hg38.fasta.gz*
 .snakemake/
 .vscode/
+microhapulator/data/hg38.mmi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated the working directory structure so report is more easily shared (#181).
+- Replaced BWA MEM with Minimap2 for read alignment (#182).
 
 
 ## [0.8] 2024-07-23

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ help: Makefile
 
 ## test:      execute the automated test suite
 test:
-	pytest -m "not known_failing" --cov=microhapulator --doctest-modules microhapulator/
+	pytest -m "not known_failing" --cov=microhapulator --doctest-modules --pyargs microhapulator
 
 ## test4:     execute the automated test suite in multithreaded mode
 test4:
-	pytest -m "not known_failing" -n 4 --cov=microhapulator --doctest-modules microhapulator/
+	pytest -m "not known_failing" -n 4 --cov=microhapulator --doctest-modules --pyargs microhapulator
 
 ## devdeps:   install development dependencies
 devdeps:

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,7 +26,7 @@ MicroHapulator depends on several Python packages.
 These are listed in `setup.py` in the main source code distribution.
 If performing a non-standard installation with `pip`, these dependencies will automatically be installed from the Python Package Index (PyPI).
 
-Preparing Illumina reads for analysis and interpretation with MicroHapulator also depends on several bioinformatics tools, including [FLASH](https://ccb.jhu.edu/software/FLASH/), [BWA](http://bio-bwa.sourceforge.net/) (or an alternative short read aligner), [SAMtools](http://www.htslib.org/), and [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/).
+Preparing Illumina reads for analysis and interpretation with MicroHapulator also depends on several bioinformatics tools, including [FLASH](https://ccb.jhu.edu/software/FLASH/), [Minimap2](https://lh3.github.io/minimap2/minimap2.html) (or an alternative short read aligner), [SAMtools](http://www.htslib.org/), and [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/).
 These software tools are installed automatically when performing a standard installation with Conda.
 Otherwise, they must be installed manually.
 
@@ -36,7 +36,7 @@ Otherwise, they must be installed manually.
 If you're setting up an environment for developing MicroHapulator, you may want to skip the procedure outlined above and use the following instead.
 
 ```bash
-conda create --new microhapulator python=3.8 flash bwa samtools fastqc
+conda create --new microhapulator python=3.11 flash minimap2 samtools fastqc
 conda activate microhapulator
 git clone https://github.com/bioforensics/MicroHapulator.git
 cd MicroHapulator/

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -87,19 +87,19 @@ This step can be skipped for single-end reads.
 ### Preprocessing: read alignment
 
 Merged reads must then be aligned to marker reference sequences before haplotypes can be called.
-In this manual we use the [bwa mem](http://bio-bwa.sourceforge.net/bwa.shtml) algorithm, but other algorithms such as [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml) would also be appropriate to use here.
+In this manual we use the [Minimap2](https://lh3.github.io/minimap2/minimap2.html) algorithm, but other algorithms such as [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml) or [bwa mem](http://bio-bwa.sourceforge.net/bwa.shtml) would also be appropriate to use here.
 
 First, the marker reference sequences must be indexed to allow NGS read alignment.
 (Note, this only needs to be done once for each reference sequence file.)
 
 ```
-bwa index marker-refr.fasta
+minimap2 -d marker-refr.mmi -k 21 -w 11 marker-refr.fasta
 ```
 
 The we align, sort, and index the merged reads.
 
 ```
-bwa mem marker-refr.fasta EVD1.extendedFrags.fastq | samtools view -bS | samtools sort -o EVD1-reads.bam -
+minimap2 -ax sr marker-refr.mmi EVD1.extendedFrags.fastq | samtools view -bS | samtools sort -o EVD1-reads.bam -
 samtools index EVD1-reads.bam
 ```
 

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -78,4 +78,4 @@ def main(args):
     else:
         message = "[MicroHapulator] building Minimap2 index, this will take some time..."
         print(message, file=sys.stderr)
-        run(["minimap2", "-d", index_path, "-k", "21", "-w", "11", hg38path], check=True)
+        run(["minimap2", "-d", str(index_path), "-k", "21", "-w", "11", str(hg38path)], check=True)

--- a/microhapulator/cli/getrefr.py
+++ b/microhapulator/cli/getrefr.py
@@ -72,14 +72,10 @@ def main(args):
         )
     if compute_shasum(hg38path) != checksum:
         raise ValueError(f"checksum failed for {str(hg38path)}")
-    index_present = True
-    for suffix in ("amb", "ann", "bwt", "pac", "sa"):
-        idxfile = Path(f"{str(hg38path)}.{suffix}")
-        if not idxfile.is_file():
-            index_present = False
-            break
-    if index_present:
-        print(f"[MicroHapulator] BWA index present, good to go!", file=sys.stderr)
+    index_path = Path(resource_filename("microhapulator", "data/hg38.mmi"))
+    if index_path.is_file():
+        print("[MicroHapulator] Minimap2 index present, good to go!", file=sys.stderr)
     else:
-        print(f"[MicroHapulator] building BWA index, this will take some time...", file=sys.stderr)
-        run(["bwa", "index", str(hg38path)], check=True)
+        message = "[MicroHapulator] building Minimap2 index, this will take some time..."
+        print(message, file=sys.stderr)
+        run(["minimap2", "-d", index_path, "-k", "21", "-w", "11", hg38path], check=True)

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -204,6 +204,12 @@ def subparser(subparsers):
         # Hidden option for testing purposes
     )
     cli.add_argument(
+        "--hg38idx",
+        default=resource_filename("microhapulator", "data/hg38.mmi"),
+        help=SUPPRESS,
+        # Hidden option for testing purposes
+    )
+    cli.add_argument(
         "--hspace",
         metavar="HS",
         default=-0.7,
@@ -237,6 +243,7 @@ def main(args):
         mhrefr=Path(args.markerrefr).resolve(),
         mhdefn=Path(args.markerdefn).resolve(),
         hg38path=Path(args.hg38).resolve(),
+        hg38index=Path(args.hg38idx).resolve(),
         thresh_static=args.static,
         thresh_dynamic=args.dynamic,
         thresh_file=args.config,

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -83,22 +83,21 @@ rule copy_and_index_marker_data:
         tsv=config["mhdefn"],
         fasta=config["mhrefr"],
     output:
-        expand("marker-refr.fasta.{suffix}", suffix=("amb", "ann", "bwt", "pac", "sa")),
         fasta="marker-refr.fasta",
+        index="marker-refr.mmi",
         tsv="marker-definitions.tsv",
     shell:
         """
         cp {input.tsv} {output.tsv}
         cp {input.fasta} {output.fasta}
-        bwa index {output.fasta}
+        minimap2 -d {output.index} -k 21 -w 11 {output.fasta}
         """
 
 
 rule map_sort_and_index:
     input:
         fastq="analysis/{sample}/{sample}-preprocessed-reads.fastq",
-        fasta="marker-refr.fasta",
-        idx=expand("marker-refr.fasta.{suffix}", suffix=("amb", "ann", "bwt", "pac", "sa")),
+        index="marker-refr.mmi",
     output:
         bam="analysis/{sample}/{sample}.bam",
         bai="analysis/{sample}/{sample}.bam.bai",
@@ -106,17 +105,15 @@ rule map_sort_and_index:
     threads: 32
     shell:
         """
-        bwa mem -t {threads} {input.fasta} {input.fastq} | samtools view -b | samtools sort -o {output.bam}
+        minimap2 -ax sr -t {threads} {input.index} {input.fastq} | samtools view -b | samtools sort -o {output.bam}
         samtools index {output.bam}
         samtools stats {output.bam} > {output.stats}
         """
 
 
 rule map_full_reference:
-    params:
-        refr=config["hg38path"],
     input:
-        full_reference_index_files(config["hg38path"]),
+        index=config["hg38index"],
         fastq="analysis/{sample}/{sample}-preprocessed-reads.fastq",
     output:
         bam="analysis/{sample}/fullrefr/{sample}-fullrefr.bam",
@@ -124,7 +121,7 @@ rule map_full_reference:
     threads: 32
     shell:
         """
-        bwa mem -t {threads} {params.refr} {input.fastq} | samtools view -b | samtools sort -o {output.bam}
+        minimap2 -ax sr -t {threads} {input.index} {input.fastq} | samtools view -b | samtools sort -o {output.bam}
         samtools index {output.bam}
         """
 

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -18,10 +18,6 @@ from pkg_resources import resource_filename
 import shutil
 
 
-def full_reference_index_files(fasta):
-    return [f"{fasta}.{sfx}" for sfx in ("amb", "ann", "bwt", "pac", "sa")]
-
-
 include: "preproc-paired.smk" if config["paired"] else "preproc-single.smk"
 
 
@@ -234,10 +230,10 @@ rule plot_haplotype_calls:
 
 rule download_and_index_full_reference:
     output:
-        full_reference_index_files(config["hg38path"]),
+        fasta=config["hg38path"],
+        index=config["hg38index"],
     shell:
         """
-        echo 'WARNING: if you have not previously downloaded and indexed the GRCh38 assembly for use with MicroHapulator, this can take an hour or more!!!'
         mhpl8r getrefr
         """
 


### PR DESCRIPTION
This PR replaces BWA MEM with Minimap2 as the alignment program used by `mhpl8r pipe`. This yields substantial speedups especially for mapping to the entire genome.

----------

- [x] Changes are clearly described above
- [ ] ~~Any relevant issue threads are referenced in the description~~
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
