### PR TITLE
New alerts in final report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Alignment gaps are now marked instead of ignored (#185).
+- Tables were added to the final report to list markers with large numbers of discarded reads or reads containing gaps (#186).
 
 
 ## [0.8.1] 2024-09-12

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -180,6 +180,14 @@ def subparser(subparsers):
         help="filter out reads that are less than LT bp long; LT=50 by default",
     )
     cli.add_argument(
+        "-D",
+        "--discard-alert",
+        metavar="DA",
+        type=float,
+        default=0.25,
+        help="issue an alert in the final report for each marker whose read discard rate (proportion of reads that could not be typed) exceeds DA; by default DA=0.25",
+    )
+    cli.add_argument(
         "-c",
         "--config",
         metavar="CSV",
@@ -250,6 +258,7 @@ def main(args):
         paired=args.reads_are_paired,
         ambiguous_thresh=args.ambiguous_thresh,
         length_thresh=args.length_thresh,
+        thresh_discard_alert=args.discard_alert,
         hspace=args.hspace,
     )
     snakefile = resource_filename("microhapulator", "workflows/analysis.smk")

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -193,7 +193,7 @@ def subparser(subparsers):
         metavar="GA",
         type=float,
         default=0.05,
-        help="issue an alert in the final report for each marker whose gap rate (proportion of reads containing one or more gap alleles) exceeds DA; by default DA=0.25",
+        help="issue an alert in the final report for each marker whose gap rate (proportion of reads containing one or more gap alleles) exceeds DA; by default DA=0.05",
     )
     cli.add_argument(
         "-c",

--- a/microhapulator/cli/pipe.py
+++ b/microhapulator/cli/pipe.py
@@ -188,6 +188,14 @@ def subparser(subparsers):
         help="issue an alert in the final report for each marker whose read discard rate (proportion of reads that could not be typed) exceeds DA; by default DA=0.25",
     )
     cli.add_argument(
+        "-G",
+        "--gap-alert",
+        metavar="GA",
+        type=float,
+        default=0.05,
+        help="issue an alert in the final report for each marker whose gap rate (proportion of reads containing one or more gap alleles) exceeds DA; by default DA=0.25",
+    )
+    cli.add_argument(
         "-c",
         "--config",
         metavar="CSV",
@@ -259,6 +267,7 @@ def main(args):
         ambiguous_thresh=args.ambiguous_thresh,
         length_thresh=args.length_thresh,
         thresh_discard_alert=args.discard_alert,
+        thresh_gap_alert=args.gap_alert,
         hspace=args.hspace,
     )
     snakefile = resource_filename("microhapulator", "workflows/analysis.smk")

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -284,15 +284,19 @@
                         <tr>
                             <th>Marker</th>
                             <th>Sample</th>
+                            <th class="alnrt">Discarded Reads</th>
+                            <th class="alnrt">Total Reads</th>
                             <th class="alnrt">% Reads Discarded</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for (marker, sample, rate) in typing_summary.high_discard_markers %}
+                        {% for n, row in typing_summary.high_discard_markers.iterrows() %}
                         <tr>
-                            <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{ marker }}</a></td>
-                            <td>{{ sample }}</td>
-                            <td class="alnrt">{{ "{:.1f}".format(rate * 100) }}%</td>
+                            <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{ row.Marker }}</a></td>
+                            <td>{{ row.Sample }}</td>
+                            <td class="alnrt">{{ "{:,d}".format(row.TotalReads - row.TypedReads) }}</td>
+                            <td class="alnrt">{{ "{:,d}".format(row.TotalReads) }}</td>
+                            <td class="alnrt">{{ "{:.1f}".format(row.DiscardRate * 100) }}%</td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -310,15 +314,19 @@
                         <tr>
                             <th>Marker</th>
                             <th>Sample</th>
-                            <th class="alnrt">% Reads Containing Gaps</th>
+                            <th class="alnrt">Reads Containing Gaps</th>
+                            <th class="alnrt">Typed Reads</th>
+                            <th class="alnrt">% Gapped Reads</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for (marker, sample, rate) in typing_summary.high_gap_markers %}
+                        {% for n, row in typing_summary.high_gap_markers.iterrows() %}
                         <tr>
-                            <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{ marker }}</a></td>
-                            <td>{{ sample }}</td>
-                            <td class="alnrt">{{ "{:.1f}".format(rate * 100) }}%</td>
+                            <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{ row.Marker }}</a></td>
+                            <td>{{ row.Sample }}</td>
+                            <td class="alnrt">{{ "{:,d}".format(row.GappedReads) }}</td>
+                            <td class="alnrt">{{ "{:,d}".format(row.TypedReads) }}</td>
+                            <td class="alnrt">{{ "{:.1f}".format(row.GappedRate * 100) }}%</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -273,6 +273,32 @@
                     </tbody>
                 </table>
             </div>
+            {% if typing_summary.has_high_discard_markers %}
+            <p class="title">
+                <strong>Table 4.3</strong>: The following markers contain a large proportion of discarded reads (untyped reads that do not span all SNPs at the locus).
+                Markers with &gt;{{ "{:.1f}".format(discard_alert_threshold * 100) }}% discarded reads are shown here—this behavior can be configured with the <code>--discard-alert</code> option (e.g. <code>--discard-alert={{ discard_alert_threshold }}</code>).
+            </p>
+            <div class="scrollwrapper">
+                <table id="discard_rates_table" class="pagination_table">
+                    <thead>
+                        <tr>
+                            <th>Marker</th>
+                            <th>Sample</th>
+                            <th class="alnrt">% Reads Discarded</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for (marker, sample, rate) in typing_summary.high_discard_markers %}
+                        <tr>
+                            <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{ marker }}</a></td>
+                            <td>{{ sample }}</td>
+                            <td class="alnrt">{{ "{:.1f}".format(rate * 100) }}%</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% endif %}
 
             <a name="filters"></a>
             <h2>Genotype Calling</h2>

--- a/microhapulator/data/template.html
+++ b/microhapulator/data/template.html
@@ -299,6 +299,32 @@
                 </table>
             </div>
             {% endif %}
+            {% if typing_summary.has_high_gap_markers %}
+            <p class="title">
+                <strong>Table 4.4</strong>: The following markers contain a large proportion of reads with gap alleles (reads with alignment gaps spanning one or more SNPs at the locus).
+                Markers with &gt;{{ "{:.1f}".format(gap_alert_threshold * 100) }}% discarded reads are shown here—this behavior can be configured with the <code>--gap-alert</code> option (e.g. <code>--gap-alert={{ gap_alert_threshold }}</code>).
+            </p>
+            <div class="scrollwrapper">
+                <table id="gap_rates_table" class="pagination_table">
+                    <thead>
+                        <tr>
+                            <th>Marker</th>
+                            <th>Sample</th>
+                            <th class="alnrt">% Reads Containing Gaps</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for (marker, sample, rate) in typing_summary.high_gap_markers %}
+                        <tr>
+                            <td><a href="marker-detail-report.html?marker={{marker}}" target="_blank">{{ marker }}</a></td>
+                            <td>{{ sample }}</td>
+                            <td class="alnrt">{{ "{:.1f}".format(rate * 100) }}%</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% endif %}
 
             <a name="filters"></a>
             <h2>Genotype Calling</h2>

--- a/microhapulator/pipe/reporter.py
+++ b/microhapulator/pipe/reporter.py
@@ -68,6 +68,7 @@ class OverviewReporter:
             ambiguous_read_threshold=self.thresholds.ambiguous,
             read_length_threshold=self.thresholds.min_read_length,
             discard_alert_threshold=self.thresholds.discard_alert,
+            gap_alert_threshold=self.thresholds.gap_alert,
         )
         return output
 

--- a/microhapulator/pipe/reporter.py
+++ b/microhapulator/pipe/reporter.py
@@ -67,6 +67,7 @@ class OverviewReporter:
             reads_are_paired=self.reads_are_paired,
             ambiguous_read_threshold=self.thresholds.ambiguous,
             read_length_threshold=self.thresholds.min_read_length,
+            discard_alert_threshold=self.thresholds.discard_alert,
         )
         return output
 

--- a/microhapulator/pipe/typestats.py
+++ b/microhapulator/pipe/typestats.py
@@ -32,11 +32,13 @@ class TypingSummary(dict):
 
     @property
     def high_discard_markers(self):
-        rates = list()
+        tables = list()
         for sample, stats in self.items():
-            for marker, rate in stats.high_discard_rates.items():
-                rates.append((marker, sample, rate))
-        return sorted(rates)
+            table = stats.high_discard_rates
+            table["Sample"] = sample
+            tables.append(table)
+        table = pd.concat(tables)
+        return table.sort_values(["Marker", "Sample"])
 
     @property
     def has_high_gap_markers(self):
@@ -47,11 +49,13 @@ class TypingSummary(dict):
 
     @property
     def high_gap_markers(self):
-        rates = list()
+        tables = list()
         for sample, stats in self.items():
-            for marker, rate in stats.high_gap_rates.items():
-                rates.append((marker, sample, rate))
-        return sorted(rates)
+            table = stats.high_gap_rates
+            table["Sample"] = sample
+            tables.append(table)
+        table = pd.concat(tables)
+        return table.sort_values(["Marker", "Sample"])
 
 
 @dataclass
@@ -59,8 +63,8 @@ class TypingStats:
     attempted_events: Dict[str, int]
     successful_events: Dict[str, int]
     typing_rates: Dict[str, float]
-    high_discard_rates: Dict[str, float]
-    high_gap_rates: Dict[str, float]
+    high_discard_rates: pd.DataFrame
+    high_gap_rates: pd.DataFrame
 
     @property
     def attempted(self):
@@ -103,9 +107,7 @@ class TypingStats:
             successful[marker] = row.TypedReads
             rates[marker] = row.TypingRate
         filename = f"{workdir}/analysis/{sample}/{sample}-discard-rate.tsv"
-        table = pd.read_csv(filename, sep="\t")
-        high_discard = table.set_index("Marker")["DiscardRate"].to_dict()
+        high_discard = pd.read_csv(filename, sep="\t")
         filename = f"{workdir}/analysis/{sample}/{sample}-gapped-rate.tsv"
-        table = pd.read_csv(filename, sep="\t")
-        high_gap = table.set_index("Marker")["GappedRate"].to_dict()
+        high_gap = pd.read_csv(filename, sep="\t")
         return cls(attempted, successful, rates, high_discard, high_gap)

--- a/microhapulator/pipe/typestats.py
+++ b/microhapulator/pipe/typestats.py
@@ -38,6 +38,21 @@ class TypingSummary(dict):
                 rates.append((marker, sample, rate))
         return sorted(rates)
 
+    @property
+    def has_high_gap_markers(self):
+        for stats in self.values():
+            if len(stats.high_gap_rates) > 0:
+                return True
+        return False
+
+    @property
+    def high_gap_markers(self):
+        rates = list()
+        for sample, stats in self.items():
+            for marker, rate in stats.high_gap_rates.items():
+                rates.append((marker, sample, rate))
+        return sorted(rates)
+
 
 @dataclass
 class TypingStats:
@@ -45,6 +60,7 @@ class TypingStats:
     successful_events: Dict[str, int]
     typing_rates: Dict[str, float]
     high_discard_rates: Dict[str, float]
+    high_gap_rates: Dict[str, float]
 
     @property
     def attempted(self):
@@ -89,4 +105,7 @@ class TypingStats:
         filename = f"{workdir}/analysis/{sample}/{sample}-discard-rate.tsv"
         table = pd.read_csv(filename, sep="\t")
         high_discard = table.set_index("Marker")["DiscardRate"].to_dict()
-        return cls(attempted, successful, rates, high_discard)
+        filename = f"{workdir}/analysis/{sample}/{sample}-gapped-rate.tsv"
+        table = pd.read_csv(filename, sep="\t")
+        high_gap = table.set_index("Marker")["GappedRate"].to_dict()
+        return cls(attempted, successful, rates, high_discard, high_gap)

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -437,7 +437,7 @@ class TypingResult(Profile):
                 rate = num_gap_reads / num_typed_reads
             entry = (marker, num_typed_reads, num_gap_reads, rate)
             data.append(entry)
-        return pd.DataFrame(data, columns=["Marker", "TypedReads", "GappedReads", "GappedRate"])
+        return pd.DataFrame(data, columns=["Marker", "GappedReads", "TypedReads", "GappedRate"])
 
     @property
     def gttype(self):

--- a/microhapulator/profile.py
+++ b/microhapulator/profile.py
@@ -424,6 +424,21 @@ class TypingResult(Profile):
             data["TypingRate"].append(rate)
         return pd.DataFrame(data)
 
+    def gap_rate(self):
+        data = []
+        for marker, mdata in self.data["markers"].items():
+            num_typed_reads, num_gap_reads = 0, 0
+            for mhallele, count in mdata["typing_result"].items():
+                num_typed_reads += count
+                if "-" in mhallele:
+                    num_gap_reads += count
+            rate = 0.0
+            if num_typed_reads > 0 and num_gap_reads > 0:
+                rate = num_gap_reads / num_typed_reads
+            entry = (marker, num_typed_reads, num_gap_reads, rate)
+            data.append(entry)
+        return pd.DataFrame(data, columns=["Marker", "TypedReads", "GappedReads", "GappedRate"])
+
     @property
     def gttype(self):
         return "TypingResult"

--- a/microhapulator/tests/test_pipe.py
+++ b/microhapulator/tests/test_pipe.py
@@ -64,6 +64,7 @@ def test_pipe_gbr_usc10(tmp_path):
         "--threads=1",
         "--static=5",
         "--dynamic=0.02",
+        "--gap-alert=0.001",
     ]
     args = microhapulator.cli.get_parser().parse_args(arglist)
     microhapulator.cli.pipe.main(args)
@@ -74,7 +75,10 @@ def test_pipe_gbr_usc10(tmp_path):
     report = tmp_path / "report" / "report.html"
     assert report.is_file()
     with open(report, "r") as fh:
-        assert "Uniform read lengths for each sample" in fh.read()
+        contents = fh.read()
+        assert "Uniform read lengths for each sample" in contents
+        assert "Table 4.3" not in contents
+        assert "Table 4.4" in contents
     profile = tmp_path / "analysis" / "gbr-usc" / "profiles" / "gbr-usc-quant.csv"
     assert profile.is_file()
     expected = pd.read_csv(data_file("gbr-usc-profile.csv"))
@@ -84,6 +88,11 @@ def test_pipe_gbr_usc10(tmp_path):
     assert len(call_pngs) == 10
     assert (tmp_path / "analysis" / "read-mapping-qc.png").is_file()
     assert (tmp_path / "report" / "img" / "read-mapping-qc.png").is_file()
+    gapped_file = tmp_path / "analysis" / "gbr-usc" / "gbr-usc-gapped-rate.tsv"
+    gapped_rate = pd.read_csv(gapped_file, sep="\t")
+    assert len(gapped_rate) == 4
+    assert list(gapped_rate.Marker) == ["mh02USC-2pA", "mh04USC-4pA", "mh06USC-6pA", "mh09USC-9pA"]
+    assert list(gapped_rate.TypedReads) == [2, 2, 2, 2]
 
 
 def test_pipe_jpt_usc10_single(tmp_path):

--- a/microhapulator/thresholds.py
+++ b/microhapulator/thresholds.py
@@ -21,6 +21,7 @@ class ThresholdIndex:
         ambiguous=0.2,
         min_read_length=50,
         discard_alert=0.25,
+        gap_alert=0.05,
         workdir=".",
     ):
         self.global_static = static
@@ -30,6 +31,7 @@ class ThresholdIndex:
         self.ambiguous = ambiguous
         self.min_read_length = min_read_length
         self.discard_alert = discard_alert
+        self.gap_alert = gap_alert
 
     def set(self, marker, static=None, dynamic=None):
         if static:
@@ -55,6 +57,7 @@ class ThresholdIndex:
         ambiguous=0.2,
         min_read_length=50,
         discard_alert=0.25,
+        gap_alert=0.05,
     ):
         index = cls(
             static=global_static,
@@ -62,6 +65,7 @@ class ThresholdIndex:
             ambiguous=ambiguous,
             min_read_length=min_read_length,
             discard_alert=discard_alert,
+            gap_alert=gap_alert,
         )
         if configfile:
             config = pd.read_csv(configfile, sep=None, engine="python")

--- a/microhapulator/thresholds.py
+++ b/microhapulator/thresholds.py
@@ -14,13 +14,22 @@ import pandas as pd
 
 
 class ThresholdIndex:
-    def __init__(self, static=5, dynamic=0.035, ambiguous=0.2, min_read_length=50, workdir="."):
+    def __init__(
+        self,
+        static=5,
+        dynamic=0.035,
+        ambiguous=0.2,
+        min_read_length=50,
+        discard_alert=0.25,
+        workdir=".",
+    ):
         self.global_static = static
         self.global_dynamic = dynamic
         self.marker_static = {}
         self.marker_dynamic = {}
         self.ambiguous = ambiguous
         self.min_read_length = min_read_length
+        self.discard_alert = discard_alert
 
     def set(self, marker, static=None, dynamic=None):
         if static:
@@ -45,12 +54,14 @@ class ThresholdIndex:
         global_dynamic=0.02,
         ambiguous=0.2,
         min_read_length=50,
+        discard_alert=0.25,
     ):
         index = cls(
             static=global_static,
             dynamic=global_dynamic,
             ambiguous=ambiguous,
             min_read_length=min_read_length,
+            discard_alert=discard_alert,
         )
         if configfile:
             config = pd.read_csv(configfile, sep=None, engine="python")

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -174,7 +174,6 @@ rule check_discard_rate:
         rates = result.typing_rate()
         rates["DiscardRate"] = 1.0 - rates.TypingRate
         rates = rates[rates.DiscardRate > params.threshold]
-        rates = rates[["Marker", "DiscardRate"]]
         rates.to_csv(output.tsv, sep="\t", index=False, float_format="%.4f")
 
 


### PR DESCRIPTION
In #183, MicroHapulator was updated to mark gap alleles as `-` instead of leaving them empty, causing the read to be discarded. This allows the user to distinguish between SNPs that are not covered by the read and SNPs that are covered by the read but have an alignment gap. The prevalence of reads with gaps can elucidate the presence of indel variants.

In this PR, two new tables are added to report potentially problematic markers. Table 4.3 shows markers that have a high proportion of aligned reads (default >25%) that don't span all SNPs. Table 4.4 shows markers with a high proportion of reads (default >5%) containing alignment gaps. The presence of either such artifact is important for troubleshooting the success of a sequencing run and the analysis and interpretation of a typing result.

Closes #184.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
