### PR TITLE
Compress intermediate FASTQ files

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -19,7 +19,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install minimap2 samtools fastqc tabix
-        which bgzip
         curl -L -O http://ccb.jhu.edu/software/FLASH/FLASH-1.2.11-Linux-x86_64.tar.gz && tar -xzf FLASH-1.2.11-Linux-x86_64.tar.gz && sudo cp FLASH-1.2.11-Linux-x86_64/flash /usr/local/bin/ && rm -r FLASH-1.2.11*
         python -m pip install --upgrade pip
         pip install .

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,7 +18,8 @@ jobs:
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install minimap2 samtools fastqc
+        sudo apt-get install minimap2 samtools fastqc tabix
+        which bgzip
         curl -L -O http://ccb.jhu.edu/software/FLASH/FLASH-1.2.11-Linux-x86_64.tar.gz && tar -xzf FLASH-1.2.11-Linux-x86_64.tar.gz && sudo cp FLASH-1.2.11-Linux-x86_64/flash /usr/local/bin/ && rm -r FLASH-1.2.11*
         python -m pip install --upgrade pip
         pip install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+### Changed
+- Intermediate FASTQ files are now bgzip compressed to reduce storage requirements (#189).
+
+
 ## [0.8.4] 2024-09-16
 
 ### Fixed

--- a/microhapulator/pipe/filter.py
+++ b/microhapulator/pipe/filter.py
@@ -12,6 +12,7 @@
 
 from Bio import SeqIO
 from dataclasses import dataclass
+from gzip import open as gzopen
 from microhapulator import open as mhopen
 
 
@@ -70,10 +71,10 @@ class PairedReadFilterCounts:
 
 class PairedReadOutputStream:
     def __init__(self, prefix):
-        self.r1 = open(f"{prefix}-ambig-filtered-R1.fastq", "w")
-        self.r2 = open(f"{prefix}-ambig-filtered-R2.fastq", "w")
-        self.r1_mates = open(f"{prefix}-ambig-R1-mates.fastq", "w")
-        self.r2_mates = open(f"{prefix}-ambig-R2-mates.fastq", "w")
+        self.r1 = gzopen(f"{prefix}-ambig-filtered-R1.fastq.gz", "wt")
+        self.r2 = gzopen(f"{prefix}-ambig-filtered-R2.fastq.gz", "wt")
+        self.r1_mates = gzopen(f"{prefix}-ambig-R1-mates.fastq.gz", "wt")
+        self.r2_mates = gzopen(f"{prefix}-ambig-R2-mates.fastq.gz", "wt")
 
     def __del__(self):
         self.r1.close()
@@ -99,7 +100,7 @@ class AmbigPairedReadFilter(PairedReadFilter):
 class SingleReadFilter:
     def __init__(self, reads_in, reads_out):
         self.reads_in = mhopen(reads_in, "r")
-        self.reads_out = open(reads_out, "w")
+        self.reads_out = gzopen(reads_out, "wt")
         self.num_reads_failed = 0
         self.num_reads_passed = 0
 

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -96,7 +96,7 @@ rule copy_and_index_marker_data:
 
 rule map_sort_and_index:
     input:
-        fastq="analysis/{sample}/{sample}-preprocessed-reads.fastq",
+        fastq="analysis/{sample}/{sample}-preprocessed-reads.fastq.gz",
         index="marker-refr.mmi",
     output:
         bam="analysis/{sample}/{sample}.bam",
@@ -114,7 +114,7 @@ rule map_sort_and_index:
 rule map_full_reference:
     input:
         index=config["hg38index"],
-        fastq="analysis/{sample}/{sample}-preprocessed-reads.fastq",
+        fastq="analysis/{sample}/{sample}-preprocessed-reads.fastq.gz",
     output:
         bam="analysis/{sample}/fullrefr/{sample}-fullrefr.bam",
         bai="analysis/{sample}/fullrefr/{sample}-fullrefr.bam.bai",

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -90,6 +90,7 @@ rule merge:
             {input} \
             2>&1 | tee {output.log}
         bgzip analysis/{wildcards.sample}/{wildcards.sample}.extendedFrags.fastq analysis/{wildcards.sample}/{wildcards.sample}.notCombined_*.fastq
+        ls -lhp analysis/{wildcards.sample}/*.fastq*
         """
 
 

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -89,8 +89,9 @@ rule merge:
             --output-prefix analysis/{wildcards.sample}/{wildcards.sample} \
             {input} \
             2>&1 | tee {output.log}
-        bgzip analysis/{wildcards.sample}/{wildcards.sample}.extendedFrags.fastq analysis/{wildcards.sample}/{wildcards.sample}.notCombined_*.fastq
-        ls -lhp analysis/{wildcards.sample}/*.fastq*
+        bgzip analysis/{wildcards.sample}/{wildcards.sample}.extendedFrags.fastq
+        bgzip analysis/{wildcards.sample}/{wildcards.sample}.notCombined_1.fastq
+        bgzip analysis/{wildcards.sample}/{wildcards.sample}.notCombined_2.fastq
         """
 
 

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -57,10 +57,10 @@ rule filter_ambiguous:
     input:
         lambda wildcards: sorted([fq for fq in config["readfiles"] if wildcards.sample in fq]),
     output:
-        filtered_r1="analysis/{sample}/{sample}-ambig-filtered-R1.fastq",
-        filtered_r2="analysis/{sample}/{sample}-ambig-filtered-R2.fastq",
-        mates_r1="analysis/{sample}/{sample}-ambig-R1-mates.fastq",
-        mates_r2="analysis/{sample}/{sample}-ambig-R2-mates.fastq",
+        filtered_r1="analysis/{sample}/{sample}-ambig-filtered-R1.fastq.gz",
+        filtered_r2="analysis/{sample}/{sample}-ambig-filtered-R2.fastq.gz",
+        mates_r1="analysis/{sample}/{sample}-ambig-R1-mates.fastq.gz",
+        mates_r2="analysis/{sample}/{sample}-ambig-R2-mates.fastq.gz",
         counts="analysis/{sample}/{sample}-ambig-read-counts.txt",
     params:
         ambig_thresh=config["ambiguous_thresh"],
@@ -77,7 +77,9 @@ rule merge:
         r1=rules.filter_ambiguous.output.filtered_r1,
         r2=rules.filter_ambiguous.output.filtered_r2,
     output:
-        mergedfq="analysis/{sample}/{sample}.extendedFrags.fastq",
+        mergedfq="analysis/{sample}/{sample}.extendedFrags.fastq.gz",
+        orphan1fq="analysis/{sample}/{sample}.notCombined_1.fastq.gz",
+        orphan2fq="analysis/{sample}/{sample}.notCombined_2.fastq.gz",
         log="analysis/{sample}/flash.log",
     threads: 8
     shell:
@@ -87,6 +89,7 @@ rule merge:
             --output-prefix analysis/{wildcards.sample}/{wildcards.sample} \
             {input} \
             2>&1 | tee {output.log}
+        bgzip analysis/{wildcards.sample}/*.extendedFrags.fastq analysis/{wildcards.sample}/*.notCombined_?.fastq
         """
 
 
@@ -94,8 +97,8 @@ rule filter_length:
     input:
         mergedfq=rules.merge.output.mergedfq,
     output:
-        length_filtered="analysis/{sample}/{sample}-length-filtered.fastq",
-        linkedfq="analysis/{sample}/{sample}-preprocessed-reads.fastq",
+        length_filtered="analysis/{sample}/{sample}-length-filtered.fastq.gz",
+        linkedfq="analysis/{sample}/{sample}-preprocessed-reads.fastq.gz",
         counts="analysis/{sample}/{sample}-length-filtered-read-counts.txt",
     params:
         length_thresh=config["length_thresh"],

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -89,7 +89,7 @@ rule merge:
             --output-prefix analysis/{wildcards.sample}/{wildcards.sample} \
             {input} \
             2>&1 | tee {output.log}
-        bgzip analysis/{wildcards.sample}/*.extendedFrags.fastq analysis/{wildcards.sample}/*.notCombined_?.fastq
+        bgzip analysis/{wildcards.sample}/{wildcards.sample}.extendedFrags.fastq analysis/{wildcards.sample}/{wildcards.sample}.notCombined_*.fastq
         """
 
 

--- a/microhapulator/workflows/preproc-single.smk
+++ b/microhapulator/workflows/preproc-single.smk
@@ -50,7 +50,7 @@ rule filter_ambiguous:
     input:
         lambda wildcards: sorted([fq for fq in config["readfiles"] if wildcards.sample in fq]),
     output:
-        filtered_fq="analysis/{sample}/{sample}-ambig-filtered.fastq",
+        filtered_fq="analysis/{sample}/{sample}-ambig-filtered.fastq.gz",
         counts="analysis/{sample}/{sample}-ambig-read-counts.txt",
     params:
         ambig_thresh=config["ambiguous_thresh"],
@@ -66,8 +66,8 @@ rule filter_length:
     input:
         fq=rules.filter_ambiguous.output.filtered_fq,
     output:
-        length_filtered="analysis/{sample}/{sample}-length-filtered.fastq",
-        linkedfq="analysis/{sample}/{sample}-preprocessed-reads.fastq",
+        length_filtered="analysis/{sample}/{sample}-length-filtered.fastq.gz",
+        linkedfq="analysis/{sample}/{sample}-preprocessed-reads.fastq.gz",
         counts="analysis/{sample}/{sample}-length-filtered-read-counts.txt",
     params:
         length_thresh=config["length_thresh"],


### PR DESCRIPTION
This PR updates the end-to-end analysis workflow to compress intermediate FASTQ files and reduce storage requirements for the working directory.

Closes #188.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
