### PR TITLE
Snakemake version 8+ support

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Colons are now used instead of commas to separate SNP alleles in microhap alleles (#192).
 - Implemented Python 3.12 support by integrating happer package and increasing minimum version of MicroHapDB dependency (#193).
 - Updated working directory organization to provide additional structure (#194).
+- Snakemake is now invoked using its new Python API, requiring a minimum version of 8.0 and Python 3.11+ (#195).
 
 ### Fixed
 - Bug with handling marker vs. locus identifiers when running `mhpl8r seq` (#190).

--- a/microhapulator/workflows/analysis.smk
+++ b/microhapulator/workflows/analysis.smk
@@ -211,7 +211,9 @@ rule apply_filters:
     params:
         static=f"--static {config['thresh_static']}",
         dynamic=f"--dynamic {config['thresh_dynamic']}",
-        threshfile="" if config["thresh_file"] == "" else f"--config {config['thresh_file']}",
+        threshfile=(
+            "" if config["thresh_file"] in ("", None) else f"--config {config['thresh_file']}"
+        ),
     shell:
         "mhpl8r filter {input} --out {output} {params.static} {params.dynamic} {params.threshfile}"
 
@@ -270,7 +272,7 @@ rule plot_haplotype_calls:
         result = TypingResult(fromfile=input.result)
         mhapi.plot_haplotype_calls(
             result,
-            "analysis/{}/03typing/callplots".format(wildcards.sample),
+            f"analysis/{wildcards.sample}/03typing/callplots",
             sample=wildcards.sample,
         )
 

--- a/microhapulator/workflows/preproc-paired.smk
+++ b/microhapulator/workflows/preproc-paired.smk
@@ -40,8 +40,7 @@ rule fastqc:
         outfiles = sorted(Path(params.outdir).glob("*.html"))
         for end, outfile in enumerate(outfiles, 1):
             outfile = Path(outfile)
-            # Snakemake f-strings break with Python 3.12: https://github.com/snakemake/snakemake/issues/2648
-            linkfile = "{}/R{}-fastqc.html".format(params.outdir, end)
+            linkfile = f"{params.outdir}/R{end}-fastqc.html"
             symlink(outfile.name, linkfile)
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "pulp==2.3.1",
         "scipy>=1.7",
         "seaborn>=0.13.2",
-        "snakemake>=7.15.2,<8.0",
+        "snakemake>=8",
         "termgraph>=0.5",
         "tqdm>=4.0",
     ],


### PR DESCRIPTION
This PR implements support for Snakemake version 8.

----------

- [x] Changes are clearly described above
- [x] Any relevant issue threads are referenced in the description
- [x] Any new features are tested (see the [development manual](https://microhapulator.readthedocs.io/en/stable/devel.html) for details)
- [x] CLI documentation (see [docs/cli.md](docs/cli.md)) and Python API documentation (see [microhapulator/api.py](microhapulator/api.py)) are up-to-date and in sync
- [x] Substantial changes are documented in CHANGELOG.md (see https://keepachangelog.com/en/1.0.0/)
